### PR TITLE
reset recordingContainers when nwbfile is finalized

### DIFF
--- a/src/nwb/NWBFile.cpp
+++ b/src/nwb/NWBFile.cpp
@@ -42,6 +42,7 @@ void NWBFile::initialize()
 
 void NWBFile::finalize()
 {
+  recordingContainers.reset();
   io->close();
 }
 

--- a/src/nwb/NWBFile.hpp
+++ b/src/nwb/NWBFile.hpp
@@ -121,10 +121,14 @@ private:
   void cacheSpecifications(const std::string& specPath,
                            const std::string& versionNumber);
 
-  const std::string identifierText;
-  std::shared_ptr<BaseIO> io;
+  /**
+   * @brief Holds the TimeSeries objects that have been created in the nwb file.
+   */
   std::unique_ptr<RecordingContainers> recordingContainers =
       std::make_unique<RecordingContainers>("RecordingContainers");
+
+  const std::string identifierText;
+  std::shared_ptr<BaseIO> io;
 };
 
 /**

--- a/src/nwb/NWBFile.hpp
+++ b/src/nwb/NWBFile.hpp
@@ -122,7 +122,8 @@ private:
                            const std::string& versionNumber);
 
   /**
-   * @brief Holds the Containers (usually TimeSeries) objects that have been created in the nwb file for recording.
+   * @brief Holds the Container (usually TimeSeries) objects that have been
+   * created in the nwb file for recording.
    */
   std::unique_ptr<RecordingContainers> recordingContainers =
       std::make_unique<RecordingContainers>("RecordingContainers");

--- a/src/nwb/NWBFile.hpp
+++ b/src/nwb/NWBFile.hpp
@@ -122,7 +122,7 @@ private:
                            const std::string& versionNumber);
 
   /**
-   * @brief Holds the TimeSeries objects that have been created in the nwb file.
+   * @brief Holds the Containers (usually TimeSeries) objects that have been created in the nwb file for recording.
    */
   std::unique_ptr<RecordingContainers> recordingContainers =
       std::make_unique<RecordingContainers>("RecordingContainers");


### PR DESCRIPTION
Fix https://github.com/NeurodataWithoutBorders/aqnwb/issues/43. 

Previously the datasets created by `NWBFile` and held in `recordingContainers` were automatically deleted, these changes explicitly reset `recordingContainers` to a `nullptr` when the nwbfile is finalized