### PR TITLE
Add missing requirement to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Below is a high-level overview of the project structure and capabilities we are 
 * HDF5
 * Boost
 * Doxygen (optional, documentation building is skipped if missing)
+* cppcheck (optional, only needed when building in developer mode `dev`)
 
 
 # Building and installing

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ Below is a high-level overview of the project structure and capabilities we are 
 * HDF5
 * Boost
 * Doxygen (optional, documentation building is skipped if missing)
-* cppcheck (optional, only needed when building in developer mode `dev`)
-
+* Additional requirements for developers (mode `dev`)
+    * cppcheck
+    * clang-format
 
 # Building and installing
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Below is a high-level overview of the project structure and capabilities we are 
 * CMake `>= 3.15`
 * HDF5
 * Boost
-* Doxygen (optional, documentation building is skipped if missing)
+* Additional requirements for building the documentation (optional)
+    * Doxygen
+    * Graphviz
 * Additional requirements for developers (mode `dev`)
     * cppcheck
     * clang-format


### PR DESCRIPTION
While following the instructions for installing in developer mode, I ran into the issue that the build was failing because cmake was trying to run `cppcheck`, which was missing on my system. This PR adds `cppcheck` to the list of requirements in README to clarify. 