### PR TITLE
fix electricalSeries default inputs

### DIFF
--- a/src/nwb/NWBFile.cpp
+++ b/src/nwb/NWBFile.cpp
@@ -58,8 +58,8 @@ Status NWBFile::createFileStructure()
   io->createGroup("/stimulus/presentation");
   io->createGroup("/stimulus/templates");
   io->createGroup("/general");
-  io->createGroup("general/devices");
-  io->createGroup("general/extracellular_ephys");
+  io->createGroup("/general/devices");
+  io->createGroup("/general/extracellular_ephys");
 
   io->createGroup("/specifications");
   io->createReferenceAttribute("/specifications", "/", ".specloc");
@@ -86,16 +86,15 @@ Status NWBFile::createElectricalSeries(
   std::string rootPath = "/acquisition/";
 
   // Setup electrode table
-  std::string electrodeTablePath = "general/extracellular_ephys/electrodes/";
-  ElectrodeTable elecTable = ElectrodeTable(electrodeTablePath, io);
+  ElectrodeTable elecTable = ElectrodeTable(io);
   elecTable.initialize();
 
   // Create continuous datasets
   for (const auto& channelVector : recordingArrays) {
     // Setup electrodes and devices
     std::string groupName = channelVector[0].groupName;
-    std::string devicePath = "general/devices/" + groupName;
-    std::string electrodePath = "general/extracellular_ephys/" + groupName;
+    std::string devicePath = "/general/devices/" + groupName;
+    std::string electrodePath = "/general/extracellular_ephys/" + groupName;
     std::string electricalSeriesPath = rootPath + groupName;
 
     Device device = Device(devicePath, io, "description", "unknown");
@@ -111,8 +110,6 @@ Status NWBFile::createElectricalSeries(
         io,
         dataType,
         channelVector,
-        elecTable.getPath(),
-        "volts",
         "Stores continuously sampled voltage data from an "
         "extracellular ephys recording",
         SizeArray {0, channelVector.size()},

--- a/src/nwb/ecephys/ElectricalSeries.cpp
+++ b/src/nwb/ecephys/ElectricalSeries.cpp
@@ -1,5 +1,7 @@
 #include "nwb/ecephys/ElectricalSeries.hpp"
 
+#include "nwb/file/ElectrodeTable.hpp"
+
 using namespace AQNWB::NWB;
 
 // ElectricalSeries
@@ -66,7 +68,7 @@ void ElectricalSeries::initialize()
   io->createCommonNWBAttributes(
       getPath() + "/electrodes", "hdmf-common", "DynamicTableRegion", "");
   io->createReferenceAttribute(
-      electrodesTablePath, getPath() + "/electrodes", "table");
+      ElectrodeTable::electrodeTablePath, getPath() + "/electrodes", "table");
 }
 
 Status ElectricalSeries::writeChannel(SizeType channelInd,

--- a/src/nwb/ecephys/ElectricalSeries.cpp
+++ b/src/nwb/ecephys/ElectricalSeries.cpp
@@ -9,8 +9,6 @@ ElectricalSeries::ElectricalSeries(const std::string& path,
                                    std::shared_ptr<BaseIO> io,
                                    const BaseDataType& dataType,
                                    const Types::ChannelVector& channelVector,
-                                   const std::string& electrodesTablePath,
-                                   const std::string& unit,
                                    const std::string& description,
                                    const SizeArray& dsetSize,
                                    const SizeArray& chunkSize,
@@ -20,7 +18,7 @@ ElectricalSeries::ElectricalSeries(const std::string& path,
     : TimeSeries(path,
                  io,
                  dataType,
-                 unit,
+                 "volts",  // default unit for Electrical Series
                  description,
                  channelVector[0].comments,
                  dsetSize,
@@ -29,7 +27,6 @@ ElectricalSeries::ElectricalSeries(const std::string& path,
                  resolution,
                  offset)
     , channelVector(channelVector)
-    , electrodesTablePath(electrodesTablePath)
 {
 }
 

--- a/src/nwb/ecephys/ElectricalSeries.hpp
+++ b/src/nwb/ecephys/ElectricalSeries.hpp
@@ -75,11 +75,6 @@ public:
   Types::ChannelVector channelVector;
 
   /**
-   * @brief Path to the electrodes table this time series references
-   */
-  std::string electrodesTablePath = "/general/extracellular_ephys/electrodes/";
-
-  /**
    * @brief Pointer to channel-specific conversion factor dataset.
    */
   std::unique_ptr<BaseRecordingData> channelConversion;

--- a/src/nwb/ecephys/ElectricalSeries.hpp
+++ b/src/nwb/ecephys/ElectricalSeries.hpp
@@ -20,8 +20,6 @@ public:
    * @param io A shared pointer to the IO object.
    * @param dataType The data type to use for storing the recorded voltage
    * @param channelVector The electrodes to use for recording
-   * @param electrodesTablePath Path to the electrodes table
-   * @param unit Unit for the electrical signal. Must be "volts".
    * @param description The description of the TimeSeries.
    * @param dsetSize Initial size of the main dataset. This must be a vector
    *                 with two elements. The first element specifies the length
@@ -41,11 +39,9 @@ public:
                    std::shared_ptr<BaseIO> io,
                    const BaseDataType& dataType,
                    const Types::ChannelVector& channelVector,
-                   const std::string& electrodesTablePath,
-                   const std::string& unit = "volts",
-                   const std::string& description = "no description",
-                   const SizeArray& dsetSize = SizeArray {0},
-                   const SizeArray& chunkSize = SizeArray {1},
+                   const std::string& description,
+                   const SizeArray& dsetSize,
+                   const SizeArray& chunkSize,
                    const float& conversion = 1.0f,
                    const float& resolution = -1.0f,
                    const float& offset = 0.0f);
@@ -81,7 +77,7 @@ public:
   /**
    * @brief Path to the electrodes table this time series references
    */
-  std::string electrodesTablePath;
+  std::string electrodesTablePath = "/general/extracellular_ephys/electrodes/";
 
   /**
    * @brief Pointer to channel-specific conversion factor dataset.

--- a/src/nwb/file/ElectrodeTable.cpp
+++ b/src/nwb/file/ElectrodeTable.cpp
@@ -7,10 +7,13 @@ using namespace AQNWB::NWB;
 // ElectrodeTable
 
 /** Constructor */
-ElectrodeTable::ElectrodeTable(const std::string& path,
-                               std::shared_ptr<BaseIO> io,
+ElectrodeTable::ElectrodeTable(std::shared_ptr<BaseIO> io,
                                const std::string& description)
-    : DynamicTable(path, io, description)
+    : DynamicTable(
+        "/general/extracellular_ephys/electrodes/",  // default value for
+                                                     // electrodes table
+        io,
+        description)
 {
 }
 

--- a/src/nwb/file/ElectrodeTable.cpp
+++ b/src/nwb/file/ElectrodeTable.cpp
@@ -9,11 +9,9 @@ using namespace AQNWB::NWB;
 /** Constructor */
 ElectrodeTable::ElectrodeTable(std::shared_ptr<BaseIO> io,
                                const std::string& description)
-    : DynamicTable(
-        "/general/extracellular_ephys/electrodes/",  // default value for
-                                                     // electrodes table
-        io,
-        description)
+    : DynamicTable(electrodeTablePath,  // use the electrodeTablePath
+                   io,
+                   description)
 {
 }
 

--- a/src/nwb/file/ElectrodeTable.hpp
+++ b/src/nwb/file/ElectrodeTable.hpp
@@ -17,13 +17,11 @@ class ElectrodeTable : public DynamicTable
 public:
   /**
    * @brief Constructor.
-   * @param path The path of the table.
    * @param io The shared pointer to the BaseIO object.
    * @param description The description of the table (default: "metadata about
    * extracellular electrodes").
    */
-  ElectrodeTable(const std::string& path,
-                 std::shared_ptr<BaseIO> io,
+  ElectrodeTable(std::shared_ptr<BaseIO> io,
                  const std::string& description =
                      "metadata about extracellular electrodes");
 

--- a/src/nwb/file/ElectrodeTable.hpp
+++ b/src/nwb/file/ElectrodeTable.hpp
@@ -83,6 +83,12 @@ public:
   std::unique_ptr<VectorData> locationsDataset =
       std::make_unique<VectorData>(); /**< The locations dataset. */
 
+  /**
+   * @brief The path to the ElectrodeTable.
+   */
+  inline const static std::string electrodeTablePath =
+      "/general/extracellular_ephys/electrodes/";
+
 private:
   /**
    * @brief The channel information from the acquisition system.

--- a/tests/testEcephys.cpp
+++ b/tests/testEcephys.cpp
@@ -48,10 +48,11 @@ TEST_CASE("ElectricalSeries", "[ecephys]")
     std::string path = getTestFilePath("ElectricalSeries.h5");
     std::shared_ptr<BaseIO> io = createIO("HDF5", path);
     io->open();
+    io->createGroup("/general");
+    io->createGroup("/general/extracellular_ephys");
 
     // setup electrode table, device, and electrode group
-    std::string elecTablePath = "/electrodes/";
-    NWB::ElectrodeTable elecTable = NWB::ElectrodeTable(elecTablePath, io);
+    NWB::ElectrodeTable elecTable = NWB::ElectrodeTable(io);
     elecTable.initialize();
 
     // setup electrical series
@@ -60,8 +61,6 @@ TEST_CASE("ElectricalSeries", "[ecephys]")
                               io,
                               dataType,
                               mockArrays[0],
-                              elecTable.getPath(),
-                              "volts",
                               "no description",
                               SizeArray {0, mockArrays[0].size()},
                               SizeArray {1, 1});
@@ -104,10 +103,11 @@ TEST_CASE("ElectricalSeries", "[ecephys]")
     std::string path = getTestFilePath("ElectricalSeriesSampleTracking.h5");
     std::shared_ptr<BaseIO> io = createIO("HDF5", path);
     io->open();
+    io->createGroup("/general");
+    io->createGroup("/general/extracellular_ephys");
 
     // setup electrode table
-    std::string elecTablePath = "/electrodes/";
-    NWB::ElectrodeTable elecTable = NWB::ElectrodeTable(elecTablePath, io);
+    NWB::ElectrodeTable elecTable = NWB::ElectrodeTable(io);
     elecTable.initialize();
 
     // setup electrical series
@@ -116,8 +116,6 @@ TEST_CASE("ElectricalSeries", "[ecephys]")
                               io,
                               dataType,
                               mockArrays[0],
-                              elecTable.getPath(),
-                              "volts",
                               "no description",
                               SizeArray {0, mockArrays[0].size()},
                               SizeArray {1, 1});

--- a/tests/testFile.cpp
+++ b/tests/testFile.cpp
@@ -11,7 +11,7 @@ using namespace AQNWB;
 
 TEST_CASE("ElectrodeTable", "[ecephys]")
 {
-  std::string path = "/electrodes/";
+  std::string path = "/general/extracellular_ephys/electrodes/";
   SECTION("test initialization")
   {
     std::string filename = getTestFilePath("electrodeTable.h5");
@@ -28,7 +28,7 @@ TEST_CASE("ElectrodeTable", "[ecephys]")
         Channel("ch2", "array0", channelIDs[2], 2),
     };
 
-    NWB::ElectrodeTable electrodeTable(path, io);
+    NWB::ElectrodeTable electrodeTable(io);
     electrodeTable.initialize();
     electrodeTable.addElectrodes(channels);
     electrodeTable.finalize();
@@ -52,7 +52,9 @@ TEST_CASE("ElectrodeTable", "[ecephys]")
     std::string filename = getTestFilePath("electrodeTableNoData.h5");
     std::shared_ptr<BaseIO> io = std::make_unique<HDF5::HDF5IO>(filename);
     io->open();
-    NWB::ElectrodeTable electrodeTable(path, io);
+    io->createGroup("/general");
+    io->createGroup("/general/extracellular_ephys");
+    NWB::ElectrodeTable electrodeTable(io);
     electrodeTable.initialize();
   }
 

--- a/tests/testFile.cpp
+++ b/tests/testFile.cpp
@@ -11,7 +11,6 @@ using namespace AQNWB;
 
 TEST_CASE("ElectrodeTable", "[ecephys]")
 {
-  std::string path = "/general/extracellular_ephys/electrodes/";
   SECTION("test initialization")
   {
     std::string filename = getTestFilePath("electrodeTable.h5");
@@ -35,7 +34,8 @@ TEST_CASE("ElectrodeTable", "[ecephys]")
 
     // Check if id datasets are created correctly
     SizeType numChannels = 3;
-    std::unique_ptr<BaseRecordingData> id_data = io->getDataSet(path + "id");
+    std::unique_ptr<BaseRecordingData> id_data =
+        io->getDataSet(NWB::ElectrodeTable::electrodeTablePath + "id");
     std::unique_ptr<HDF5::HDF5RecordingData> idDataset(
         dynamic_cast<HDF5::HDF5RecordingData*>(id_data.release()));
     int* buffer = new int[numChannels];


### PR DESCRIPTION
Fix several issues related to the inputs to `ElectricalSeries` in preparation for new data types that will inherit from ElectricalSeries.
* fix #53 
* fix #54 
* fix #55

Regarding #53, I didn't realize the path was specified in the schema and there is only a single `ElectrodesTable` - that makes things easier!