### PR TITLE
Enable generation of CALL_GRAPH and CALLER_GRAPH in the docs

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -17,6 +17,10 @@ OUTPUT_DIRECTORY = "@DOXYGEN_OUTPUT_DIRECTORY@"
 # Enable Markdown support
 MARKDOWN_SUPPORT = YES
 
+# Enable the call and caller graphs (this increases built time but seems reasonable for AqNWB)
+CALL_GRAPH           = YES
+CALLER_GRAPH         = YES
+
 # set relative include paths
 FULL_PATH_NAMES = YES
 STRIP_FROM_PATH = "@PROJECT_SOURCE_DIR@/include" "@PROJECT_SOURCE_DIR@"


### PR DESCRIPTION
This PR enables the generation of caller and call graphs in Doxygen for all functions, providing an idea about who is calling the function and which functions are called by a function. E.g., here the call graph for ``createElectricalSeries``

<img width="1091" alt="Screen Shot 2024-09-01 at 7 53 05 PM" src="https://github.com/user-attachments/assets/8b321e11-2494-403a-bf37-8da814d353a7">


**Note**
* While this can increases the built time for the docs, on my laptop the difference seemed to be minimal
* Extracting the call/caller graph is not perfect in Doxygen. In particular in the case of virtual functions where we may call the function on the base type and not the derived type, callers seem to get missed at times. However, the graphs still seem useful, even if they are not perfect. 