### PR TITLE
add flag for boost library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,12 +76,13 @@ target_include_directories(
 )
 
 target_compile_features(aqnwb_aqnwb PUBLIC cxx_std_17)
+target_compile_definitions(aqnwb_aqnwb PUBLIC BOOST_NO_CXX98_FUNCTION_BASE)
 
 # ---- Additional libraries needed ----
 find_package(HDF5 REQUIRED COMPONENTS CXX)
 include_directories(${HDF5_INCLUDE_DIRS})
 
-find_package(Boost 1.80 REQUIRED)
+find_package(Boost REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 
 target_link_libraries(aqnwb_aqnwb ${HDF5_CXX_LIBRARIES} ${Boost_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ target_compile_features(aqnwb_aqnwb PUBLIC cxx_std_17)
 find_package(HDF5 REQUIRED COMPONENTS CXX)
 include_directories(${HDF5_INCLUDE_DIRS})
 
-find_package(Boost REQUIRED)
+find_package(Boost 1.80 REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 
 target_link_libraries(aqnwb_aqnwb ${HDF5_CXX_LIBRARIES} ${Boost_LIBRARIES})

--- a/docs/pages/userdocs/install.dox
+++ b/docs/pages/userdocs/install.dox
@@ -8,7 +8,7 @@
  *  - A C++17-compliant compiler
  *  - [CMake >= 3.15](https://cmake.org)
  *  - [HDF5 >= 1.10](https://github.com/HDFGroup/hdf5)
- *  - [Boost](https://www.boost.org/)
+ *  - [Boost >= 1.80](https://www.boost.org/)
  *
  * \section userbuild_build_sec Build
  *

--- a/docs/pages/userdocs/install.dox
+++ b/docs/pages/userdocs/install.dox
@@ -8,7 +8,7 @@
  *  - A C++17-compliant compiler
  *  - [CMake >= 3.15](https://cmake.org)
  *  - [HDF5 >= 1.10](https://github.com/HDFGroup/hdf5)
- *  - [Boost >= 1.80](https://www.boost.org/)
+ *  - [Boost](https://www.boost.org/)
  *
  * \section userbuild_build_sec Build
  *


### PR DESCRIPTION
It seems Boost versions <1.80 were using `std::unary_function` which is no longer provided in C++17. This led to compilation errors when using an older boost version.

Edit: we can instruct Boost to avoid using deprecated functions in the cmake file to avoid setting a boost minimum requirement