### PR TITLE
Update member variable names to avoid shadowing

### DIFF
--- a/docs/pages/userdocs/workflow.dox
+++ b/docs/pages/userdocs/workflow.dox
@@ -8,94 +8,94 @@
  * For users wanting to integrate NWB with a particular data acquisition software, here
  * we outline the steps for a single recording from file creation to saving.
  *
- * 1. Create the I/O object (e.g,.  \ref AQNWB::HDF5::HDF5IO "HDF5IO") used for 
+ * 1. Create the I/O object (e.g,.  \ref AQNWB::HDF5::HDF5IO "HDF5IO") used for
  *    writing data to the file on disk.
- * 2. Create the \ref AQNWB::NWB::RecordingContainers "RecordingContainers" object 
+ * 2. Create the \ref AQNWB::NWB::RecordingContainers "RecordingContainers" object
  *    used for managing \ref AQNWB::NWB::Container "Container" objects for storing recordings.
- * 3. Create the \ref AQNWB::NWB::NWBFile "NWBFile" object used for managing and creating NWB 
+ * 3. Create the \ref AQNWB::NWB::NWBFile "NWBFile" object used for managing and creating NWB
  *    file contents.
- * 4. Create the \ref AQNWB::NWB::Container "Container" objects (e.g., 
- *    \ref AQNWB::NWB::ElectricalSeries "ElectricalSeries") used for recording and add them 
+ * 4. Create the \ref AQNWB::NWB::Container "Container" objects (e.g.,
+ *    \ref AQNWB::NWB::ElectricalSeries "ElectricalSeries") used for recording and add them
  *    to the \ref AQNWB::NWB::RecordingContainers "RecordingContainers".
  * 5. Start the recording.
  * 6. Write data.
  * 7. Stop the recording and close the \ref AQNWB::NWB::NWBFile "NWBFile".
- * 
+ *
  * Below, we walk through these steps in more detail.
- * 
- * 
+ *
+ *
  * \subsection create_io 1. Create the I/O object.
- * 
- * First, create an I/O object (e.g., \ref AQNWB::HDF5::HDF5IO "HDF5IO") used for writing 
+ *
+ * First, create an I/O object (e.g., \ref AQNWB::HDF5::HDF5IO "HDF5IO") used for writing
  * data to the file. AqNWB provides the convenience method, \ref AQNWB::createIO "createIO"
  * to create this object using one of the supported backends. For more fine-grained
- * control of different backend parameters, you can create your own `std::shared_ptr` 
+ * control of different backend parameters, you can create your own `std::shared_ptr`
  * using any of the derived \ref AQNWB::BaseIO "BaseIO" classes.
- * 
+ *
  * \snippet tests/examples/testWorkflowExamples.cpp example_workflow_io_snippet
  *
  *
  * \subsection create_recording_container 2. Create the RecordingContainer object.
- * 
- * Next, create a \ref AQNWB::NWB::RecordingContainers "RecordingContainers"  object to manage the 
- * different \ref AQNWB::NWB::Container "Container" objects with the datasets that you would 
+ *
+ * Next, create a \ref AQNWB::NWB::RecordingContainers "RecordingContainers"  object to manage the
+ * different \ref AQNWB::NWB::Container "Container" objects with the datasets that you would
  * like to write data to.
- * 
+ *
  * \snippet tests/examples/testWorkflowExamples.cpp example_workflow_recording_containers_snippet
- * 
+ *
  *
  * \subsection create_nwbfile 3. Create the NWBFile
- * 
- * Next, constructs the \ref AQNWB::NWB::NWBFile "NWBFile"  object, using the I/O object as an input. 
+ *
+ * Next, constructs the \ref AQNWB::NWB::NWBFile "NWBFile"  object, using the I/O object as an input.
  * Then, initialize the object to create the basic file structure of the NWBFile.
  *
  * \snippet tests/examples/testWorkflowExamples.cpp example_workflow_nwbfile_snippet
  *
- * 
+ *
  * \subsection create_datasets 4. Create datasets and add to RecordingContainers.
  *
- * Next, create the different data types (e.g. \ref AQNWB::NWB::ElectricalSeries "ElectricalSeries" 
- * or other AQNWB::NWB::TimeSeries "TimeSeries") that you would like to write data into. After 
- * creation, these objects are added to the  \ref AQNWB::NWB::RecordingContainers "RecordingContainers"  
- * object so that it can mana ge access and data writing during the recording process. 
- * When adding containers, ownership of the \ref AQNWB::NWB::Container "Container"  is transferred to the 
- * \ref AQNWB::NWB::RecordingContainers "RecordingContainers" object, so that we can access it again via 
- * its index. New containers will always be appended to the end of the
- * \ref AQNWB::NWB::RecordingContainers::containers "containers" object and their index can be tracked 
- * using the size of the input `recordingArrays`.
- * 
+ * Next, create the different data types (e.g. \ref AQNWB::NWB::ElectricalSeries "ElectricalSeries"
+ * or other AQNWB::NWB::TimeSeries "TimeSeries") that you would like to write data into. After
+ * creation, these objects are added to the  \ref AQNWB::NWB::RecordingContainers "RecordingContainers"
+ * object so that it can mana ge access and data writing during the recording process.
+ * When adding containers, ownership of the \ref AQNWB::NWB::Container "Container"  is transferred to the
+ * \ref AQNWB::NWB::RecordingContainers "RecordingContainers" object, so that we can access it again via
+ * its index. New containers will always be appended to the end of the private member
+ * ``RecordingContainers.m_containers` object and their index can be tracked
+ * using the \ref AQNWB::NWB::RecordingContainers::size "RecordingContainers.size" of the input `recordingArrays`.
+ *
  * \snippet tests/examples/testWorkflowExamples.cpp example_workflow_datasets_snippet
  *
  *
  * \subsection start_recording 5. Start the recording.
  *
- * Then, start the recording process with a call to the ``startRecording`` function of the I/O object. 
+ * Then, start the recording process with a call to the ``startRecording`` function of the I/O object.
  *
- *  \note 
- * When using \ref AQNWB::HDF5::HDF5IO "HDF5IO" for writing to HDF5, calling 
+ *  \note
+ * When using \ref AQNWB::HDF5::HDF5IO "HDF5IO" for writing to HDF5, calling
  * \ref AQNWB::HDF5::HDF5IO::startRecording "startRecording" will by default enable
- * \ref hdf5io_swmr "SWMR mode" to ensure file integrity and support concurrent read. 
+ * \ref hdf5io_swmr "SWMR mode" to ensure file integrity and support concurrent read.
  * As a result, no additional datasets or groups can be added to the file once a recording
  * has been started unless the file is is closed and reopened.
  *
  * \snippet tests/examples/testWorkflowExamples.cpp example_workflow_start_snippet
  *
- * 
+ *
  * \subsection write_data 6. Write data.
  *
- * During the recording process, use the \ref AQNWB::NWB::RecordingContainers "RecordingContainers" 
- * as an interface to access the various  \ref AQNWB::NWB::Container "Container" object and corresponding 
- * datasets and write blocks of data to the file. Calling `flush()` on the I/O object at any time will 
+ * During the recording process, use the \ref AQNWB::NWB::RecordingContainers "RecordingContainers"
+ * as an interface to access the various  \ref AQNWB::NWB::Container "Container" object and corresponding
+ * datasets and write blocks of data to the file. Calling `flush()` on the I/O object at any time will
  * ensure the data is moved to disk.
- * 
+ *
  * \snippet tests/examples/testWorkflowExamples.cpp example_workflow_write_snippet
  *
- * 
+ *
  * \subsection stop_recording 7. Stop the recording and finalize the file.
  *
  * When the recording process is finished, call `stopRecording` from the I/O object
  * to flush any data and close the file.
- * 
+ *
  * \snippet tests/examples/testWorkflowExamples.cpp example_workflow_stop_snippet
  *
  *

--- a/src/BaseIO.cpp
+++ b/src/BaseIO.cpp
@@ -31,9 +31,10 @@ const BaseDataType BaseDataType::DSTR = BaseDataType(T_STR, DEFAULT_STR_SIZE);
 
 // BaseIO
 
-BaseIO::BaseIO()
-    : readyToOpen(true)
-    , opened(false)
+BaseIO::BaseIO(const std::string& filename)
+    : m_filename(filename)
+    , m_readyToOpen(true)
+    , m_opened(false)
 {
 }
 
@@ -41,12 +42,17 @@ BaseIO::~BaseIO() {}
 
 bool BaseIO::isOpen() const
 {
-  return opened;
+  return m_opened;
+}
+
+std::string BaseIO::getFileName()
+{
+  return this->m_filename;
 }
 
 bool BaseIO::isReadyToOpen() const
 {
-  return readyToOpen;
+  return m_readyToOpen;
 }
 
 bool BaseIO::canModifyObjects()

--- a/src/BaseIO.cpp
+++ b/src/BaseIO.cpp
@@ -47,7 +47,7 @@ bool BaseIO::isOpen() const
 
 std::string BaseIO::getFileName()
 {
-  return this->m_filename;
+  return m_filename;
 }
 
 bool BaseIO::isReadyToOpen() const

--- a/src/BaseIO.cpp
+++ b/src/BaseIO.cpp
@@ -40,26 +40,6 @@ BaseIO::BaseIO(const std::string& filename)
 
 BaseIO::~BaseIO() {}
 
-bool BaseIO::isOpen() const
-{
-  return m_opened;
-}
-
-std::string BaseIO::getFileName()
-{
-  return m_filename;
-}
-
-bool BaseIO::isReadyToOpen() const
-{
-  return m_readyToOpen;
-}
-
-bool BaseIO::canModifyObjects()
-{
-  return true;
-}
-
 Status BaseIO::createCommonNWBAttributes(const std::string& path,
                                          const std::string& objectNamespace,
                                          const std::string& neurodataType,

--- a/src/BaseIO.hpp
+++ b/src/BaseIO.hpp
@@ -94,7 +94,7 @@ public:
   /**
    * @brief Constructor for the BaseIO class.
    */
-  BaseIO();
+  BaseIO(const std::string& filename);
 
   /**
    * @brief Copy constructor is deleted to prevent construction-copying.
@@ -115,7 +115,7 @@ public:
    * @brief Returns the full path to the file.
    * @return The full path to the file.
    */
-  virtual std::string getFileName() = 0;
+  virtual std::string getFileName();
 
   /**
    * @brief Opens the file for writing.
@@ -346,12 +346,12 @@ public:
    */
   bool isReadyToOpen() const;
 
+protected:
   /**
    * @brief The name of the file.
    */
-  const std::string filename;
+  const std::string m_filename;
 
-protected:
   /**
    * @brief Creates a new group if it does not already exist.
    * @param path The location of the group in the file.
@@ -362,12 +362,12 @@ protected:
   /**
    * @brief Whether the file is ready to be opened.
    */
-  bool readyToOpen;
+  bool m_readyToOpen;
 
   /**
    * @brief Whether the file is currently open.
    */
-  bool opened;
+  bool m_opened;
 };
 
 /**

--- a/src/BaseIO.hpp
+++ b/src/BaseIO.hpp
@@ -115,7 +115,7 @@ public:
    * @brief Returns the full path to the file.
    * @return The full path to the file.
    */
-  virtual std::string getFileName();
+  virtual std::string getFileName() const { return m_filename; }
 
   /**
    * @brief Opens the file for writing.
@@ -267,7 +267,7 @@ public:
    * override this function to check if objects can be modified.
    * @return True if the file is in a modification mode, false otherwise.
    */
-  virtual bool canModifyObjects();
+  virtual bool canModifyObjects() { return true; }
 
   /**
    * @brief Creates an extendable dataset with a given base data type, size,
@@ -338,13 +338,13 @@ public:
    * @brief Returns true if the file is open.
    * @return True if the file is open, false otherwise.
    */
-  bool isOpen() const;
+  inline bool isOpen() const { return m_opened; }
 
   /**
    * @brief Returns true if the file is able to be opened.
    * @return True if the file is able to be opened, false otherwise.
    */
-  bool isReadyToOpen() const;
+  inline bool isReadyToOpen() const { return m_readyToOpen; }
 
 protected:
   /**

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -14,32 +14,17 @@ Channel::Channel(const std::string name,
                  const float bitVolts,
                  const std::array<float, 3> position,
                  const std::string comments)
-    : name(name)
-    , groupName(groupName)
-    , groupIndex(groupIndex)
-    , localIndex(localIndex)
-    , globalIndex(globalIndex)
-    , position(position)
-    , conversion(conversion)
-    , samplingRate(samplingRate)
-    , bitVolts(bitVolts)
-    , comments(comments)
+    : m_name(name)
+    , m_groupName(groupName)
+    , m_groupIndex(groupIndex)
+    , m_localIndex(localIndex)
+    , m_globalIndex(globalIndex)
+    , m_position(position)
+    , m_conversion(conversion)
+    , m_samplingRate(samplingRate)
+    , m_bitVolts(bitVolts)
+    , m_comments(comments)
 {
 }
 
 Channel::~Channel() {}
-
-float Channel::getConversion() const
-{
-  return bitVolts / conversion;
-}
-
-float Channel::getSamplingRate() const
-{
-  return samplingRate;
-}
-
-float Channel::getBitVolts() const
-{
-  return bitVolts;
-}

--- a/src/Channel.hpp
+++ b/src/Channel.hpp
@@ -39,142 +39,166 @@ public:
   /**
    * @brief Copy constructor
    */
-   Channel(const Channel& other) = default;
+  Channel(const Channel& other) = default;
 
-   /**
-    * @brief Move constructor
-    */
-   Channel(Channel&& other) = default;
+  /**
+   * @brief Move constructor
+   */
+  Channel(Channel&& other) = default;
 
-   /**
-    * @brief Assignment operator
-    */
-   Channel& operator=(const Channel& other) = default;
+  /**
+   * @brief Assignment operator
+   */
+  Channel& operator=(const Channel& other) = default;
 
-   /**
-    * @brief Move assignment operator
-    */
-   Channel& operator=(Channel&& other) = default;
+  /**
+   * @brief Move assignment operator
+   */
+  Channel& operator=(Channel&& other) = default;
 
-   /**
+  /**
    * @brief Getter for conversion factor
    * @return The conversion value.
    */
   inline float getConversion() const { return m_bitVolts / m_conversion; }
 
-   /**
+  /**
    * @brief Getter for sampling rate of the channel.
    * @return The sampling rate value.
    */
-   inline float getSamplingRate() const { return m_samplingRate; }
+  inline float getSamplingRate() const { return m_samplingRate; }
 
-   /**
+  /**
    * @brief Getter for bitVolts floating point value of microvolts per bit
    * @return The bitVolts value.
    */
-   inline float getBitVolts() const { return m_bitVolts; }
+  inline float getBitVolts() const { return m_bitVolts; }
 
-   /**
+  /**
    * @brief Get the name of the array group the channel belongs to.
    * @return The groupName value.
    */
-   inline std::string getGroupName() const {  return m_groupName; }
+  inline std::string getGroupName() const { return m_groupName; }
 
-   /**
+  /**
    * @brief Get the name of the channel
    * @return The name value.
    */
-   inline std::string getName() const { return m_name; }
+  inline std::string getName() const { return m_name; }
 
-   /**
+  /**
    * @brief Get the array group index the channel belongs to
    * @return The groupIndex value.
    */
-   inline SizeType getGroupIndex() const { return m_groupIndex; }
+  inline SizeType getGroupIndex() const { return m_groupIndex; }
 
-   /**
+  /**
    * @brief Get the index of the channel within the recording array.
    * @return The localIndex value.
    */
-   inline SizeType getLocalIndex() const { return m_localIndex; }
+  inline SizeType getLocalIndex() const { return m_localIndex; }
 
-   /**
+  /**
    * @brief Get the index of the channel across the recording system.
    * @return The globalIndex value.
    */
-   inline SizeType getGlobalIndex() const { return m_globalIndex; }
+  inline SizeType getGlobalIndex() const { return m_globalIndex; }
 
-   /**
+  /**
    * @brief Get the coordinates of channel (x, y, z) within the recording array.
    * @return The position value.
    */
-   inline const std::array<float, 3>& getPosition() const { return m_position; }
+  inline const std::array<float, 3>& getPosition() const { return m_position; }
 
-   /**
+  /**
    * @brief Get comments about the channel
    * @return The comments value.
    */
-   inline std::string getComments() const { return m_comments; }
+  inline std::string getComments() const { return m_comments; }
 
-   /**
+  /**
    * @brief Set comments about the channel.
    * @param comments The comments to set.
    */
-   inline void setComments(const std::string& comments) { m_comments = comments; }
+  inline void setComments(const std::string& comments)
+  {
+    m_comments = comments;
+  }
 
-   /**
+  /**
    * @brief Set coordinates of channel (x, y, z) within the recording array.
    * @param position The position to set.
    */
-   inline void setPosition(const std::array<float, 3>& position) { m_position = position; }
+  inline void setPosition(const std::array<float, 3>& position)
+  {
+    m_position = position;
+  }
 
-   /**
+  /**
    * @brief Set index of channel across the recording system.
    * @param globalIndex The globalIndex to set.
    */
-   inline void setGlobalIndex(const SizeType globalIndex) { m_globalIndex = globalIndex; }
+  inline void setGlobalIndex(const SizeType globalIndex)
+  {
+    m_globalIndex = globalIndex;
+  }
 
-   /**
+  /**
    * @brief Set index of channel within the recording array.
    * @param localIndex The localIndex to set.
    */
-   inline void setLocalIndex(const SizeType localIndex) { m_localIndex = localIndex; }
+  inline void setLocalIndex(const SizeType localIndex)
+  {
+    m_localIndex = localIndex;
+  }
 
-   /**
+  /**
    * @brief Set index of array group the channel belongs to.
    * @param groupIndex The groupIndex to set.
    */
-   inline void setGroupIndex(const SizeType groupIndex) { m_groupIndex = groupIndex; }
+  inline void setGroupIndex(const SizeType groupIndex)
+  {
+    m_groupIndex = groupIndex;
+  }
 
-   /**
+  /**
    * @brief Set name of the channel.
    * @param name The name to set.
    */
-   inline void setName(const std::string& name) { m_name = name; }
+  inline void setName(const std::string& name) { m_name = name; }
 
-   /**
+  /**
    * @brief Set name of the array group the channel belongs to.
    * @param groupName The groupName to set.
    */
-   inline void setGroupName(const std::string& groupName) { m_groupName = groupName; }
+  inline void setGroupName(const std::string& groupName)
+  {
+    m_groupName = groupName;
+  }
 
-   /**
+  /**
    * @brief Set conversion factor.
    * @param conversion The conversion to set.
    */
-   inline void setConversion(const float conversion) { m_conversion = conversion; }
+  inline void setConversion(const float conversion)
+  {
+    m_conversion = conversion;
+  }
 
-   /**
+  /**
    * @brief Set sampling rate of the channel.
    * @param samplingRate The samplingRate to set.
    */
-   inline void setSamplingRate(const float samplingRate) { m_samplingRate = samplingRate; }
+  inline void setSamplingRate(const float samplingRate)
+  {
+    m_samplingRate = samplingRate;
+  }
 
-   /**
+  /**
    * @brief Set floating point value of microvolts per bit
    * @param bitVolts The bitVolts to set.
    */
-   inline void setBitVolts(const float bitVolts) { m_bitVolts = bitVolts; }
+  inline void setBitVolts(const float bitVolts) { m_bitVolts = bitVolts; }
 
 private:
   /**
@@ -182,12 +206,12 @@ private:
    */
   std::string m_comments;
 
-   /**
+  /**
    * @brief Coordinates of channel (x, y, z) within the recording array.
    */
   std::array<float, 3> m_position;
 
-   /**
+  /**
    * @brief Index of channel across the recording system.
    */
   SizeType m_globalIndex;

--- a/src/Channel.hpp
+++ b/src/Channel.hpp
@@ -134,7 +134,6 @@ public:
     m_position = position;
   }
 
-
   /**
    * @brief Set name of the channel.
    * @param name The name to set.

--- a/src/Channel.hpp
+++ b/src/Channel.hpp
@@ -37,72 +37,194 @@ public:
   ~Channel();
 
   /**
+   * @brief Copy constructor
+   */
+   Channel(const Channel& other) = default;
+
+   /**
+    * @brief Move constructor
+    */
+   Channel(Channel&& other) = default;
+
+   /**
+    * @brief Assignment operator
+    */
+   Channel& operator=(const Channel& other) = default;
+
+   /**
+    * @brief Move assignment operator
+    */
+   Channel& operator=(Channel&& other) = default;
+
+   /**
    * @brief Getter for conversion factor
    * @return The conversion value.
    */
-  float getConversion() const;
+  inline float getConversion() const { return m_bitVolts / m_conversion; }
 
-  /**
-   * @brief Getter for samplingRate
-   * @return The samplingRate value.
+   /**
+   * @brief Getter for sampling rate of the channel.
+   * @return The sampling rate value.
    */
-  float getSamplingRate() const;
+   inline float getSamplingRate() const { return m_samplingRate; }
 
-  /**
-   * @brief Getter for bitVolts
+   /**
+   * @brief Getter for bitVolts floating point value of microvolts per bit
    * @return The bitVolts value.
    */
-  float getBitVolts() const;
+   inline float getBitVolts() const { return m_bitVolts; }
 
-  /**
-   * @brief Name of the channel.
+   /**
+   * @brief Get the name of the array group the channel belongs to.
+   * @return The groupName value.
    */
-  std::string name;
+   inline std::string getGroupName() const {  return m_groupName; }
 
-  /**
-   * @brief Name of the array group the channel belongs to.
+   /**
+   * @brief Get the name of the channel
+   * @return The name value.
    */
-  std::string groupName;
+   inline std::string getName() const { return m_name; }
 
-  /**
-   * @brief Index of array group the channel belongs to.
+   /**
+   * @brief Get the array group index the channel belongs to
+   * @return The groupIndex value.
    */
-  SizeType groupIndex;
+   inline SizeType getGroupIndex() const { return m_groupIndex; }
+
+   /**
+   * @brief Get the index of the channel within the recording array.
+   * @return The localIndex value.
+   */
+   inline SizeType getLocalIndex() const { return m_localIndex; }
+
+   /**
+   * @brief Get the index of the channel across the recording system.
+   * @return The globalIndex value.
+   */
+   inline SizeType getGlobalIndex() const { return m_globalIndex; }
+
+   /**
+   * @brief Get the coordinates of channel (x, y, z) within the recording array.
+   * @return The position value.
+   */
+   inline const std::array<float, 3>& getPosition() const { return m_position; }
+
+   /**
+   * @brief Get comments about the channel
+   * @return The comments value.
+   */
+   inline std::string getComments() const { return m_comments; }
+
+   /**
+   * @brief Set comments about the channel.
+   * @param comments The comments to set.
+   */
+   inline void setComments(const std::string& comments) { m_comments = comments; }
+
+   /**
+   * @brief Set coordinates of channel (x, y, z) within the recording array.
+   * @param position The position to set.
+   */
+   inline void setPosition(const std::array<float, 3>& position) { m_position = position; }
+
+   /**
+   * @brief Set index of channel across the recording system.
+   * @param globalIndex The globalIndex to set.
+   */
+   inline void setGlobalIndex(const SizeType globalIndex) { m_globalIndex = globalIndex; }
+
+   /**
+   * @brief Set index of channel within the recording array.
+   * @param localIndex The localIndex to set.
+   */
+   inline void setLocalIndex(const SizeType localIndex) { m_localIndex = localIndex; }
+
+   /**
+   * @brief Set index of array group the channel belongs to.
+   * @param groupIndex The groupIndex to set.
+   */
+   inline void setGroupIndex(const SizeType groupIndex) { m_groupIndex = groupIndex; }
+
+   /**
+   * @brief Set name of the channel.
+   * @param name The name to set.
+   */
+   inline void setName(const std::string& name) { m_name = name; }
+
+   /**
+   * @brief Set name of the array group the channel belongs to.
+   * @param groupName The groupName to set.
+   */
+   inline void setGroupName(const std::string& groupName) { m_groupName = groupName; }
+
+   /**
+   * @brief Set conversion factor.
+   * @param conversion The conversion to set.
+   */
+   inline void setConversion(const float conversion) { m_conversion = conversion; }
+
+   /**
+   * @brief Set sampling rate of the channel.
+   * @param samplingRate The samplingRate to set.
+   */
+   inline void setSamplingRate(const float samplingRate) { m_samplingRate = samplingRate; }
+
+   /**
+   * @brief Set floating point value of microvolts per bit
+   * @param bitVolts The bitVolts to set.
+   */
+   inline void setBitVolts(const float bitVolts) { m_bitVolts = bitVolts; }
+
+private:
+  /**
+   * @brief Comments about the channel.
+   */
+  std::string m_comments;
+
+   /**
+   * @brief Coordinates of channel (x, y, z) within the recording array.
+   */
+  std::array<float, 3> m_position;
+
+   /**
+   * @brief Index of channel across the recording system.
+   */
+  SizeType m_globalIndex;
 
   /**
    * @brief Index of channel within the recording array.
    */
-  SizeType localIndex;
+  SizeType m_localIndex;
 
   /**
-   * @brief Index of channel across the recording system.
+   * @brief Index of array group the channel belongs to.
    */
-  SizeType globalIndex;
+  SizeType m_groupIndex;
 
   /**
-   * @brief Coordinates of channel (x, y, z) within the recording array.
+   * @brief Name of the channel.
    */
-  std::array<float, 3> position;
+  std::string m_name;
 
   /**
-   * @brief Comments about the channel.
+   * @brief Name of the array group the channel belongs to.
    */
-  std::string comments;
+  std::string m_groupName;
 
-private:
   /**
    * @brief Conversion factor.
    */
-  float conversion;
+  float m_conversion;
 
   /**
    * @brief Sampling rate of the channel.
    */
-  float samplingRate;
+  float m_samplingRate;
 
   /**
    * @brief floating point value of microvolts per bit
    */
-  float bitVolts;
+  float m_bitVolts;
 };
 }  // namespace AQNWB

--- a/src/hdf5/HDF5IO.cpp
+++ b/src/hdf5/HDF5IO.cpp
@@ -525,7 +525,7 @@ H5O_type_t HDF5IO::getObjectType(const std::string& path)
   // get whether path is a dataset or group
   H5O_info_t objInfo;  // Structure to hold information about the object
   H5Oget_info_by_name(
-      this - m_ > file->getId(), path.c_str(), &objInfo, H5P_DEFAULT);
+      this->m_file->getId(), path.c_str(), &objInfo, H5P_DEFAULT);
 #endif
   H5O_type_t objectType = objInfo.type;
 

--- a/src/hdf5/HDF5IO.cpp
+++ b/src/hdf5/HDF5IO.cpp
@@ -511,16 +511,12 @@ H5O_type_t HDF5IO::getObjectType(const std::string& path)
 #if H5_VERSION_GE(1, 12, 0)
   // get whether path is a dataset or group
   H5O_info_t objInfo;  // Structure to hold information about the object
-  H5Oget_info_by_name(m_file->getId(),
-                      path.c_str(),
-                      &objInfo,
-                      H5O_INFO_BASIC,
-                      H5P_DEFAULT);
+  H5Oget_info_by_name(
+      m_file->getId(), path.c_str(), &objInfo, H5O_INFO_BASIC, H5P_DEFAULT);
 #else
   // get whether path is a dataset or group
   H5O_info_t objInfo;  // Structure to hold information about the object
-  H5Oget_info_by_name(
-      m_file->getId(), path.c_str(), &objInfo, H5P_DEFAULT);
+  H5Oget_info_by_name(m_file->getId(), path.c_str(), &objInfo, H5P_DEFAULT);
 #endif
   H5O_type_t objectType = objInfo.type;
 

--- a/src/hdf5/HDF5IO.cpp
+++ b/src/hdf5/HDF5IO.cpp
@@ -28,7 +28,7 @@ HDF5IO::~HDF5IO()
 
 std::string HDF5IO::getFileName()
 {
-  return this->m_filename;
+  return m_filename;
 }
 
 Status HDF5IO::open()
@@ -44,7 +44,7 @@ Status HDF5IO::open(bool newfile)
 {
   int accFlags = 0;
 
-  if (this->m_opened)
+  if (m_opened)
     return Status::Failure;
 
   FileAccPropList fapl = FileAccPropList::DEFAULT;
@@ -55,19 +55,19 @@ Status HDF5IO::open(bool newfile)
   else
     accFlags = H5F_ACC_RDWR;
 
-  this->m_file = std::make_unique<H5::H5File>(
+  m_file = std::make_unique<H5::H5File>(
       getFileName(), accFlags, FileCreatPropList::DEFAULT, fapl);
-  this->m_opened = true;
+  m_opened = true;
 
   return Status::Success;
 }
 
 Status HDF5IO::close()
 {
-  if (this->m_file != nullptr && this->m_opened) {
-    this->m_file->close();
-    this->m_file = nullptr;
-    this->m_opened = false;
+  if (m_file != nullptr && m_opened) {
+    m_file->close();
+    m_file = nullptr;
+    m_opened = false;
   }
 
   return Status::Success;
@@ -83,7 +83,7 @@ Status checkStatus(int status)
 
 Status HDF5IO::flush()
 {
-  int status = H5Fflush(this->m_file->getId(), H5F_SCOPE_GLOBAL);
+  int status = H5Fflush(m_file->getId(), H5F_SCOPE_GLOBAL);
   return checkStatus(status);
 }
 
@@ -100,18 +100,18 @@ Status HDF5IO::createAttribute(const BaseDataType& type,
   DataType H5type;
   DataType origType;
 
-  if (!this->m_opened)
+  if (!m_opened)
     return Status::Failure;
 
   // open the group or dataset
   H5O_type_t objectType = getObjectType(path);
   switch (objectType) {
     case H5O_TYPE_GROUP:
-      gloc = this->m_file->openGroup(path);
+      gloc = m_file->openGroup(path);
       loc = &gloc;
       break;
     case H5O_TYPE_DATASET:
-      dloc = this->m_file->openDataSet(path);
+      dloc = m_file->openDataSet(path);
       loc = &dloc;
       break;
     default:
@@ -175,7 +175,7 @@ Status HDF5IO::createAttribute(const std::vector<const char*>& data,
   Attribute attr;
   hsize_t dims[1];
 
-  if (!this->m_opened)
+  if (!m_opened)
     return Status::Failure;
 
   StrType H5type(PredType::C_S1, maxSize);
@@ -185,11 +185,11 @@ Status HDF5IO::createAttribute(const std::vector<const char*>& data,
   H5O_type_t objectType = getObjectType(path);
   switch (objectType) {
     case H5O_TYPE_GROUP:
-      gloc = this->m_file->openGroup(path);
+      gloc = m_file->openGroup(path);
       loc = &gloc;
       break;
     case H5O_TYPE_DATASET:
-      dloc = this->m_file->openDataSet(path);
+      dloc = m_file->openDataSet(path);
       loc = &dloc;
       break;
     default:
@@ -232,18 +232,18 @@ Status HDF5IO::createReferenceAttribute(const std::string& referencePath,
   DataSet dloc;
   Attribute attr;
 
-  if (!this->m_opened)
+  if (!m_opened)
     return Status::Failure;
 
   // open the group or dataset
   H5O_type_t objectType = getObjectType(path);
   switch (objectType) {
     case H5O_TYPE_GROUP:
-      gloc = this->m_file->openGroup(path);
+      gloc = m_file->openGroup(path);
       loc = &gloc;
       break;
     case H5O_TYPE_DATASET:
-      dloc = this->m_file->openDataSet(path);
+      dloc = m_file->openDataSet(path);
       loc = &dloc;
       break;
     default:
@@ -260,7 +260,7 @@ Status HDF5IO::createReferenceAttribute(const std::string& referencePath,
 
     hobj_ref_t* rdata = new hobj_ref_t[sizeof(hobj_ref_t)];
 
-    this->m_file->reference(rdata, referencePath.c_str());
+    m_file->reference(rdata, referencePath.c_str());
 
     attr.write(H5::PredType::STD_REF_OBJ, rdata);
     delete[] rdata;
@@ -280,7 +280,7 @@ Status HDF5IO::createReferenceAttribute(const std::string& referencePath,
 
 Status HDF5IO::createGroup(const std::string& path)
 {
-  if (!this->m_opened)
+  if (!m_opened)
     return Status::Failure;
   try {
     this->m_file->createGroup(path);

--- a/src/hdf5/HDF5IO.cpp
+++ b/src/hdf5/HDF5IO.cpp
@@ -26,11 +26,6 @@ HDF5IO::~HDF5IO()
   close();
 }
 
-std::string HDF5IO::getFileName()
-{
-  return m_filename;
-}
-
 Status HDF5IO::open()
 {
   if (std::filesystem::exists(getFileName())) {

--- a/src/hdf5/HDF5IO.cpp
+++ b/src/hdf5/HDF5IO.cpp
@@ -364,8 +364,8 @@ Status HDF5IO::createStringDataSet(const std::string& path,
   DataType H5type = getH5Type(BaseDataType::STR(value.length()));
   DataSpace dSpace(H5S_SCALAR);
 
-  dataset =
-      std::make_unique<H5::DataSet>(this->m_file->createDataSet(path, H5type, dSpace));
+  dataset = std::make_unique<H5::DataSet>(
+      this->m_file->createDataSet(path, H5type, dSpace));
   dataset->write(value.c_str(), H5type);
 
   return Status::Success;
@@ -516,12 +516,16 @@ H5O_type_t HDF5IO::getObjectType(const std::string& path)
 #if H5_VERSION_GE(1, 12, 0)
   // get whether path is a dataset or group
   H5O_info_t objInfo;  // Structure to hold information about the object
-  H5Oget_info_by_name(
-      this->m_file->getId(), path.c_str(), &objInfo, H5O_INFO_BASIC, H5P_DEFAULT);
+  H5Oget_info_by_name(this->m_file->getId(),
+                      path.c_str(),
+                      &objInfo,
+                      H5O_INFO_BASIC,
+                      H5P_DEFAULT);
 #else
   // get whether path is a dataset or group
   H5O_info_t objInfo;  // Structure to hold information about the object
-  H5Oget_info_by_name(this-m_>file->getId(), path.c_str(), &objInfo, H5P_DEFAULT);
+  H5Oget_info_by_name(
+      this - m_ > file->getId(), path.c_str(), &objInfo, H5P_DEFAULT);
 #endif
   H5O_type_t objectType = objInfo.type;
 

--- a/src/hdf5/HDF5IO.cpp
+++ b/src/hdf5/HDF5IO.cpp
@@ -727,8 +727,3 @@ Status HDF5RecordingData::writeDataBlock(
   }
   return Status::Success;
 }
-
-const H5::DataSet* HDF5RecordingData::getDataSet()
-{
-  return this->m_dataset.get();
-};

--- a/src/hdf5/HDF5IO.cpp
+++ b/src/hdf5/HDF5IO.cpp
@@ -653,7 +653,7 @@ HDF5RecordingData::HDF5RecordingData(std::unique_ptr<H5::DataSet> data)
   this->nDimensions = nDimensions;
   this->position = std::vector<SizeType>(
       nDimensions, 0);  // Initialize position with 0 for each dimension
-  this->dSet = std::make_unique<H5::DataSet>(*data);
+  this->m_dataset = std::make_unique<H5::DataSet>(*data);
 }
 
 // HDF5RecordingData
@@ -661,7 +661,7 @@ HDF5RecordingData::HDF5RecordingData(std::unique_ptr<H5::DataSet> data)
 HDF5RecordingData::~HDF5RecordingData()
 {
   // Safety
-  dSet->flush(H5F_SCOPE_GLOBAL);
+  this->m_dataset->flush(H5F_SCOPE_GLOBAL);
 }
 
 Status HDF5RecordingData::writeDataBlock(
@@ -690,10 +690,10 @@ Status HDF5RecordingData::writeDataBlock(
     }
 
     // Adjust dataset dimensions if necessary
-    dSet->extend(dSetDims.data());
+    this->m_dataset->extend(dSetDims.data());
 
     // Set size to new size based on updated dimensionality
-    DataSpace fSpace = dSet->getSpace();
+    DataSpace fSpace = this->m_dataset->getSpace();
     fSpace.getSimpleExtentDims(dSetDims.data());
     for (int i = 0; i < nDimensions; ++i) {
       size[i] = dSetDims[i];
@@ -716,7 +716,7 @@ Status HDF5RecordingData::writeDataBlock(
 
     // Write the data
     DataType nativeType = HDF5IO::getNativeType(type);
-    dSet->write(data, nativeType, mSpace, fSpace);
+    this->m_dataset->write(data, nativeType, mSpace, fSpace);
 
     // Update position for simple extension
     for (int i = 0; i < dataShape.size(); ++i) {
@@ -734,5 +734,5 @@ Status HDF5RecordingData::writeDataBlock(
 
 const H5::DataSet* HDF5RecordingData::getDataSet()
 {
-  return dSet.get();
+  return this->m_dataset.get();
 };

--- a/src/hdf5/HDF5IO.hpp
+++ b/src/hdf5/HDF5IO.hpp
@@ -49,12 +49,6 @@ public:
   ~HDF5IO();
 
   /**
-   * @brief Returns the full path to the HDF5 file.
-   * @return The full path to the HDF5 file.
-   */
-  std::string getFileName() override;
-
-  /**
    * @brief Opens an existing file or creates a new file for writing.
    * @return The status of the file opening operation.
    */

--- a/src/hdf5/HDF5IO.hpp
+++ b/src/hdf5/HDF5IO.hpp
@@ -331,13 +331,13 @@ public:
 
 private:
   /**
-   * @brief Pointer to an extendable HDF5 dataset
-   */
-  std::unique_ptr<H5::DataSet> dSet;
-
-  /**
    * @brief Return status of HDF5 operations.
    */
   Status checkStatus(int status);
+
+  /**
+   * @brief Pointer to an extendable HDF5 dataset
+   */
+  std::unique_ptr<H5::DataSet> m_dataset;
 };
 }  // namespace AQNWB::HDF5

--- a/src/hdf5/HDF5IO.hpp
+++ b/src/hdf5/HDF5IO.hpp
@@ -268,12 +268,12 @@ protected:
 
 private:
   /**
-  * @brief the HDF5 file
-  */
+   * @brief the HDF5 file
+   */
   std::unique_ptr<H5::H5File> m_file;
   /**
-  * @brief When set do not use SWMR mode when opening the HDF5 file
-  */
+   * @brief When set do not use SWMR mode when opening the HDF5 file
+   */
   bool m_disableSWMRMode;
 };
 

--- a/src/hdf5/HDF5IO.hpp
+++ b/src/hdf5/HDF5IO.hpp
@@ -319,7 +319,7 @@ public:
    * @brief Gets a const pointer to the HDF5 dataset.
    * @return A const pointer to the HDF5 dataset.
    */
-  const H5::DataSet* getDataSet();
+  inline const H5::DataSet* getDataSet() const { return this->m_dataset.get(); }
 
 private:
   /**

--- a/src/hdf5/HDF5IO.hpp
+++ b/src/hdf5/HDF5IO.hpp
@@ -33,11 +33,6 @@ class HDF5IO : public BaseIO
 {
 public:
   /**
-   * @brief Default constructor for the HDF5IO class.
-   */
-  HDF5IO();
-
-  /**
    * @brief Constructor for the HDF5IO class that takes a file name as input.
    * @param fileName The name of the HDF5 file.
    * @param disableSWMRMode Disable recording of data in Single Writer
@@ -264,8 +259,6 @@ public:
   static H5::DataType getH5Type(BaseDataType type);
 
 protected:
-  std::string filename;
-
   /**
    * @brief Creates a new group if it does not exist.
    * @param path The location in the file of the group.
@@ -274,9 +267,14 @@ protected:
   Status createGroupIfDoesNotExist(const std::string& path) override;
 
 private:
-  std::unique_ptr<H5::H5File> file;
-  bool disableSWMRMode;  // when set do not use SWMR mode when opening the HDF5
-                         // file
+  /**
+  * @brief the HDF5 file
+  */
+  std::unique_ptr<H5::H5File> m_file;
+  /**
+  * @brief When set do not use SWMR mode when opening the HDF5 file
+  */
+  bool m_disableSWMRMode;
 };
 
 /**

--- a/src/nwb/NWBFile.cpp
+++ b/src/nwb/NWBFile.cpp
@@ -146,8 +146,8 @@ Status NWBFile::createElectricalSeries(
       Device device = Device(devicePath, m_io, "description", "unknown");
       device.initialize();
 
-      ElectrodeGroup elecGroup = ElectrodeGroup(
-          electrodePath, m_io, "description", "unknown", device);
+      ElectrodeGroup elecGroup =
+          ElectrodeGroup(electrodePath, m_io, "description", "unknown", device);
       elecGroup.initialize();
     }
 
@@ -220,8 +220,8 @@ Status NWBFile::createSpikeEventSeries(
       Device device = Device(devicePath, m_io, "description", "unknown");
       device.initialize();
 
-      ElectrodeGroup elecGroup = ElectrodeGroup(
-          electrodePath, m_io, "description", "unknown", device);
+      ElectrodeGroup elecGroup =
+          ElectrodeGroup(electrodePath, m_io, "description", "unknown", device);
       elecGroup.initialize();
     }
 
@@ -270,9 +270,8 @@ void NWBFile::cacheSpecifications(
 
   for (const auto& [name, content] : specVariables) {
     m_io->createStringDataSet("/specifications/" + specPath + "/"
-                                        + versionNumber + "/"
-                                        + std::string(name),
-                                    std::string(content));
+                                  + versionNumber + "/" + std::string(name),
+                              std::string(content));
   }
 }
 

--- a/src/nwb/NWBFile.cpp
+++ b/src/nwb/NWBFile.cpp
@@ -31,8 +31,8 @@ std::vector<SizeType> NWBFile::emptyContainerIndexes = {};
 // NWBFile
 
 NWBFile::NWBFile(const std::string& idText, std::shared_ptr<BaseIO> io)
-    : Container("/", io),
-      m_identifierText(idText)
+    : Container("/", io)
+    , m_identifierText(idText)
 
 {
 }
@@ -146,8 +146,8 @@ Status NWBFile::createElectricalSeries(
       Device device = Device(devicePath, this->m_io, "description", "unknown");
       device.initialize();
 
-      ElectrodeGroup elecGroup =
-          ElectrodeGroup(electrodePath, this->m_io, "description", "unknown", device);
+      ElectrodeGroup elecGroup = ElectrodeGroup(
+          electrodePath, this->m_io, "description", "unknown", device);
       elecGroup.initialize();
     }
 
@@ -220,8 +220,8 @@ Status NWBFile::createSpikeEventSeries(
       Device device = Device(devicePath, this->m_io, "description", "unknown");
       device.initialize();
 
-      ElectrodeGroup elecGroup =
-          ElectrodeGroup(electrodePath, this->m_io, "description", "unknown", device);
+      ElectrodeGroup elecGroup = ElectrodeGroup(
+          electrodePath, this->m_io, "description", "unknown", device);
       elecGroup.initialize();
     }
 
@@ -269,9 +269,10 @@ void NWBFile::cacheSpecifications(
   this->m_io->createGroup("/specifications/" + specPath + "/" + versionNumber);
 
   for (const auto& [name, content] : specVariables) {
-    this->m_io->createStringDataSet("/specifications/" + specPath + "/" + versionNumber
-                                + "/" + std::string(name),
-                            std::string(content));
+    this->m_io->createStringDataSet("/specifications/" + specPath + "/"
+                                        + versionNumber + "/"
+                                        + std::string(name),
+                                    std::string(content));
   }
 }
 

--- a/src/nwb/NWBFile.cpp
+++ b/src/nwb/NWBFile.cpp
@@ -42,44 +42,44 @@ NWBFile::~NWBFile() {}
 Status NWBFile::initialize(const std::string description,
                            const std::string dataCollection)
 {
-  if (std::filesystem::exists(this->m_io->getFileName())) {
-    return this->m_io->open(false);
+  if (std::filesystem::exists(m_io->getFileName())) {
+    return m_io->open(false);
   } else {
-    this->m_io->open(true);
+    m_io->open(true);
     return createFileStructure(description, dataCollection);
   }
 }
 
 Status NWBFile::finalize()
 {
-  return this->m_io->close();
+  return m_io->close();
 }
 
 Status NWBFile::createFileStructure(std::string description,
                                     std::string dataCollection)
 {
-  if (!this->m_io->canModifyObjects()) {
+  if (!m_io->canModifyObjects()) {
     return Status::Failure;
   }
 
-  this->m_io->createCommonNWBAttributes("/", "core", "NWBFile", "");
-  this->m_io->createAttribute(AQNWB::SPEC::CORE::version, "/", "nwb_version");
+  m_io->createCommonNWBAttributes("/", "core", "NWBFile", "");
+  m_io->createAttribute(AQNWB::SPEC::CORE::version, "/", "nwb_version");
 
-  this->m_io->createGroup("/acquisition");
-  this->m_io->createGroup("/analysis");
-  this->m_io->createGroup("/processing");
-  this->m_io->createGroup("/stimulus");
-  this->m_io->createGroup("/stimulus/presentation");
-  this->m_io->createGroup("/stimulus/templates");
-  this->m_io->createGroup("/general");
-  this->m_io->createGroup("/general/devices");
-  this->m_io->createGroup("/general/extracellular_ephys");
+  m_io->createGroup("/acquisition");
+  m_io->createGroup("/analysis");
+  m_io->createGroup("/processing");
+  m_io->createGroup("/stimulus");
+  m_io->createGroup("/stimulus/presentation");
+  m_io->createGroup("/stimulus/templates");
+  m_io->createGroup("/general");
+  m_io->createGroup("/general/devices");
+  m_io->createGroup("/general/extracellular_ephys");
   if (dataCollection != "") {
-    this->m_io->createStringDataSet("/general/data_collection", dataCollection);
+    m_io->createStringDataSet("/general/data_collection", dataCollection);
   }
 
-  this->m_io->createGroup("/specifications");
-  this->m_io->createReferenceAttribute("/specifications", "/", ".specloc");
+  m_io->createGroup("/specifications");
+  m_io->createReferenceAttribute("/specifications", "/", ".specloc");
 
   cacheSpecifications(
       "core", AQNWB::SPEC::CORE::version, AQNWB::SPEC::CORE::specVariables);
@@ -92,11 +92,11 @@ Status NWBFile::createFileStructure(std::string description,
 
   std::string time = getCurrentTime();
   std::vector<std::string> timeVec = {time};
-  this->m_io->createStringDataSet("/file_create_date", timeVec);
-  this->m_io->createStringDataSet("/session_description", description);
-  this->m_io->createStringDataSet("/session_start_time", time);
-  this->m_io->createStringDataSet("/timestamps_reference_time", time);
-  this->m_io->createStringDataSet("/identifier", this->m_identifierText);
+  m_io->createStringDataSet("/file_create_date", timeVec);
+  m_io->createStringDataSet("/session_description", description);
+  m_io->createStringDataSet("/session_start_time", time);
+  m_io->createStringDataSet("/timestamps_reference_time", time);
+  m_io->createStringDataSet("/identifier", m_identifierText);
 
   return Status::Success;
 }
@@ -108,7 +108,7 @@ Status NWBFile::createElectricalSeries(
     RecordingContainers* recordingContainers,
     std::vector<SizeType>& containerIndexes)
 {
-  if (!this->m_io->canModifyObjects()) {
+  if (!m_io->canModifyObjects()) {
     return Status::Failure;
   }
 
@@ -118,9 +118,9 @@ Status NWBFile::createElectricalSeries(
 
   // Setup electrode table if it was not yet created
   bool electrodeTableCreated =
-      this->m_io->objectExists(ElectrodeTable::electrodeTablePath);
+      m_io->objectExists(ElectrodeTable::electrodeTablePath);
   if (!electrodeTableCreated) {
-    this->m_electrodeTable = std::make_unique<ElectrodeTable>(this->m_io);
+    m_electrodeTable = std::make_unique<ElectrodeTable>(this->m_io);
     this->m_electrodeTable->initialize();
 
     // Add electrode information to table (does not write to datasets yet)

--- a/src/nwb/NWBFile.cpp
+++ b/src/nwb/NWBFile.cpp
@@ -31,8 +31,9 @@ std::vector<SizeType> NWBFile::emptyContainerIndexes = {};
 // NWBFile
 
 NWBFile::NWBFile(const std::string& idText, std::shared_ptr<BaseIO> io)
-    : identifierText(idText)
-    , io(io)
+    : Container("/", io),
+      m_identifierText(idText)
+
 {
 }
 
@@ -95,7 +96,7 @@ Status NWBFile::createFileStructure(std::string description,
   io->createStringDataSet("/session_description", description);
   io->createStringDataSet("/session_start_time", time);
   io->createStringDataSet("/timestamps_reference_time", time);
-  io->createStringDataSet("/identifier", identifierText);
+  io->createStringDataSet("/identifier", this->m_identifierText);
 
   return Status::Success;
 }
@@ -119,12 +120,12 @@ Status NWBFile::createElectricalSeries(
   bool electrodeTableCreated =
       io->objectExists(ElectrodeTable::electrodeTablePath);
   if (!electrodeTableCreated) {
-    elecTable = std::make_unique<ElectrodeTable>(io);
-    elecTable->initialize();
+    this->m_electrodeTable = std::make_unique<ElectrodeTable>(io);
+    this->m_electrodeTable->initialize();
 
     // Add electrode information to table (does not write to datasets yet)
     for (const auto& channelVector : recordingArrays) {
-      elecTable->addElectrodes(channelVector);
+      this->m_electrodeTable->addElectrodes(channelVector);
     }
   }
 
@@ -168,7 +169,7 @@ Status NWBFile::createElectricalSeries(
   // write electrode information to datasets
   // (requires that the ElectrodeGroup has been written)
   if (!electrodeTableCreated) {
-    elecTable->finalize();
+    this->m_electrodeTable->finalize();
   }
 
   return Status::Success;
@@ -193,12 +194,12 @@ Status NWBFile::createSpikeEventSeries(
   bool electrodeTableCreated =
       io->objectExists(ElectrodeTable::electrodeTablePath);
   if (!electrodeTableCreated) {
-    elecTable = std::make_unique<ElectrodeTable>(io);
-    elecTable->initialize();
+    this->m_electrodeTable = std::make_unique<ElectrodeTable>(io);
+    this->m_electrodeTable->initialize();
 
     // Add electrode information to table (does not write to datasets yet)
     for (const auto& channelVector : recordingArrays) {
-      elecTable->addElectrodes(channelVector);
+      this->m_electrodeTable->addElectrodes(channelVector);
     }
   }
 
@@ -251,7 +252,7 @@ Status NWBFile::createSpikeEventSeries(
   // write electrode information to datasets
   // (requires that the ElectrodeGroup has been written)
   if (!electrodeTableCreated) {
-    elecTable->finalize();
+    this->m_electrodeTable->finalize();
   }
 
   return Status::Success;

--- a/src/nwb/NWBFile.cpp
+++ b/src/nwb/NWBFile.cpp
@@ -162,7 +162,7 @@ Status NWBFile::createElectricalSeries(
         SizeArray {CHUNK_XSIZE, 0});
     electricalSeries->initialize();
     recordingContainers->addContainer(std::move(electricalSeries));
-    containerIndexes.push_back(recordingContainers->containers.size() - 1);
+    containerIndexes.push_back(recordingContainers->size() - 1);
   }
 
   // write electrode information to datasets
@@ -245,7 +245,7 @@ Status NWBFile::createSpikeEventSeries(
         chunkSize);
     spikeEventSeries->initialize();
     recordingContainers->addContainer(std::move(spikeEventSeries));
-    containerIndexes.push_back(recordingContainers->containers.size() - 1);
+    containerIndexes.push_back(recordingContainers->size() - 1);
   }
 
   // write electrode information to datasets

--- a/src/nwb/NWBFile.cpp
+++ b/src/nwb/NWBFile.cpp
@@ -134,7 +134,7 @@ Status NWBFile::createElectricalSeries(
     const std::string& recordingName = recordingNames[i];
 
     // Setup electrodes and devices
-    std::string groupName = channelVector[0].groupName;
+    std::string groupName = channelVector[0].getGroupName();
     std::string devicePath = "/general/devices/" + groupName;
     std::string electrodePath = "/general/extracellular_ephys/" + groupName;
     std::string electricalSeriesPath = acquisitionPath + "/" + recordingName;
@@ -208,7 +208,7 @@ Status NWBFile::createSpikeEventSeries(
     const std::string& recordingName = recordingNames[i];
 
     // Setup electrodes and devices
-    std::string groupName = channelVector[0].groupName;
+    std::string groupName = channelVector[0].getGroupName();
     std::string devicePath = "/general/devices/" + groupName;
     std::string electrodePath = "/general/extracellular_ephys/" + groupName;
     std::string spikeEventSeriesPath = acquisitionPath + "/" + recordingName;

--- a/src/nwb/NWBFile.hpp
+++ b/src/nwb/NWBFile.hpp
@@ -7,12 +7,12 @@
 #include <string_view>
 #include <vector>
 
-#include "nwb/hdmf/base/Container.hpp"
 #include "BaseIO.hpp"
 #include "Types.hpp"
 #include "nwb/RecordingContainers.hpp"
 #include "nwb/base/TimeSeries.hpp"
 #include "nwb/file/ElectrodeTable.hpp"
+#include "nwb/hdmf/base/Container.hpp"
 
 /*!
  * \namespace AQNWB::NWB
@@ -162,7 +162,6 @@ private:
    */
   std::unique_ptr<ElectrodeTable> m_electrodeTable;
   const std::string m_identifierText;
-
 };
 
 }  // namespace AQNWB::NWB

--- a/src/nwb/NWBFile.hpp
+++ b/src/nwb/NWBFile.hpp
@@ -7,6 +7,7 @@
 #include <string_view>
 #include <vector>
 
+#include "nwb/hdmf/base/Container.hpp"
 #include "BaseIO.hpp"
 #include "Types.hpp"
 #include "nwb/RecordingContainers.hpp"
@@ -24,7 +25,7 @@ namespace AQNWB::NWB
  * @brief The NWBFile class provides an interface for setting up and managing
  * the NWB file.
  */
-class NWBFile
+class NWBFile : public Container
 {
 public:
   /**
@@ -152,11 +153,16 @@ private:
       const std::array<std::pair<std::string_view, std::string_view>, N>&
           specVariables);
 
-  std::unique_ptr<ElectrodeTable> elecTable;
-  const std::string identifierText;
-  std::shared_ptr<BaseIO> io;
-  static std::vector<SizeType> emptyContainerIndexes;
   inline const static std::string acquisitionPath = "/acquisition";
+  static std::vector<SizeType> emptyContainerIndexes;
+
+private:
+  /**
+   * @brief The ElectrodeTable for the file
+   */
+  std::unique_ptr<ElectrodeTable> m_electrodeTable;
+  const std::string m_identifierText;
+
 };
 
 }  // namespace AQNWB::NWB

--- a/src/nwb/RecordingContainers.cpp
+++ b/src/nwb/RecordingContainers.cpp
@@ -14,15 +14,15 @@ RecordingContainers::~RecordingContainers() {}
 
 void RecordingContainers::addContainer(std::unique_ptr<Container> container)
 {
-  this->containers.push_back(std::move(container));
+  this->m_containers.push_back(std::move(container));
 }
 
 Container* RecordingContainers::getContainer(const SizeType& containerInd)
 {
-  if (containerInd >= this->containers.size()) {
+  if (containerInd >= this->m_containers.size()) {
     return nullptr;
   } else {
-    return this->containers[containerInd].get();
+    return this->m_containers[containerInd].get();
   }
 }
 
@@ -78,4 +78,9 @@ Status RecordingContainers::writeSpikeEventData(const SizeType& containerInd,
     return Status::Failure;
 
   ses->writeSpike(numSamples, numChannels, data, timestamps);
+}
+
+SizeType  RecordingContainers::size()
+{
+   return this->m_containers.size();
 }

--- a/src/nwb/RecordingContainers.cpp
+++ b/src/nwb/RecordingContainers.cpp
@@ -80,7 +80,7 @@ Status RecordingContainers::writeSpikeEventData(const SizeType& containerInd,
   ses->writeSpike(numSamples, numChannels, data, timestamps);
 }
 
-SizeType  RecordingContainers::size()
+SizeType RecordingContainers::size()
 {
-   return this->m_containers.size();
+  return this->m_containers.size();
 }

--- a/src/nwb/RecordingContainers.cpp
+++ b/src/nwb/RecordingContainers.cpp
@@ -14,15 +14,15 @@ RecordingContainers::~RecordingContainers() {}
 
 void RecordingContainers::addContainer(std::unique_ptr<Container> container)
 {
-  this->m_containers.push_back(std::move(container));
+  m_containers.push_back(std::move(container));
 }
 
 Container* RecordingContainers::getContainer(const SizeType& containerInd)
 {
-  if (containerInd >= this->m_containers.size()) {
+  if (containerInd >= m_containers.size()) {
     return nullptr;
   } else {
-    return this->m_containers[containerInd].get();
+    return m_containers[containerInd].get();
   }
 }
 
@@ -82,5 +82,5 @@ Status RecordingContainers::writeSpikeEventData(const SizeType& containerInd,
 
 SizeType RecordingContainers::size()
 {
-  return this->m_containers.size();
+  return m_containers.size();
 }

--- a/src/nwb/RecordingContainers.cpp
+++ b/src/nwb/RecordingContainers.cpp
@@ -79,8 +79,3 @@ Status RecordingContainers::writeSpikeEventData(const SizeType& containerInd,
 
   ses->writeSpike(numSamples, numChannels, data, timestamps);
 }
-
-SizeType RecordingContainers::size()
-{
-  return m_containers.size();
-}

--- a/src/nwb/RecordingContainers.cpp
+++ b/src/nwb/RecordingContainers.cpp
@@ -40,7 +40,7 @@ Status RecordingContainers::writeTimeseriesData(
     return Status::Failure;
 
   // write data and timestamps to datasets
-  if (channel.localIndex == 0) {
+  if (channel.getLocalIndex() == 0) {
     // write with timestamps if it's the first channel
     return ts->writeData(dataShape, positionOffset, data, timestamps);
   } else {
@@ -62,7 +62,7 @@ Status RecordingContainers::writeElectricalSeriesData(
   if (es == nullptr)
     return Status::Failure;
 
-  es->writeChannel(channel.localIndex, numSamples, data, timestamps);
+  es->writeChannel(channel.getLocalIndex(), numSamples, data, timestamps);
 }
 
 Status RecordingContainers::writeSpikeEventData(const SizeType& containerInd,

--- a/src/nwb/RecordingContainers.hpp
+++ b/src/nwb/RecordingContainers.hpp
@@ -105,8 +105,21 @@ public:
                              const void* data,
                              const void* timestamps);
 
-  std::vector<std::unique_ptr<Container>> containers;
-  std::string name;
+  /**
+  * @brief Get the number of recording containers
+  */
+  SizeType size();
+
+private:
+  /**
+  * @brief The Containers used for recording
+  */
+  std::vector<std::unique_ptr<Container>> m_containers;
+
+  /**
+  * @brief The name of the collection of recording containers
+  */
+  std::string m_name;
 };
 
 }  // namespace AQNWB::NWB

--- a/src/nwb/RecordingContainers.hpp
+++ b/src/nwb/RecordingContainers.hpp
@@ -106,19 +106,19 @@ public:
                              const void* timestamps);
 
   /**
-  * @brief Get the number of recording containers
-  */
+   * @brief Get the number of recording containers
+   */
   SizeType size();
 
 private:
   /**
-  * @brief The Containers used for recording
-  */
+   * @brief The Containers used for recording
+   */
   std::vector<std::unique_ptr<Container>> m_containers;
 
   /**
-  * @brief The name of the collection of recording containers
-  */
+   * @brief The name of the collection of recording containers
+   */
   std::string m_name;
 };
 

--- a/src/nwb/RecordingContainers.hpp
+++ b/src/nwb/RecordingContainers.hpp
@@ -108,7 +108,7 @@ public:
   /**
    * @brief Get the number of recording containers
    */
-  SizeType size();
+  inline SizeType size() const { return m_containers.size(); }
 
 private:
   /**

--- a/src/nwb/base/TimeSeries.cpp
+++ b/src/nwb/base/TimeSeries.cpp
@@ -37,24 +37,20 @@ void TimeSeries::initialize()
   Container::initialize();
 
   // setup attributes
-  this->m_io->createCommonNWBAttributes(
-      this->m_path, "core", neurodataType, description);
-  this->m_io->createAttribute(comments, this->m_path, "comments");
+  m_io->createCommonNWBAttributes(m_path, "core", neurodataType, description);
+  m_io->createAttribute(comments, m_path, "comments");
 
   // setup datasets
-  this->data =
-      std::unique_ptr<BaseRecordingData>(this->m_io->createArrayDataSet(
-          dataType, dsetSize, chunkSize, this->m_path + "/data"));
-  this->m_io->createDataAttributes(this->m_path, conversion, resolution, unit);
+  this->data = std::unique_ptr<BaseRecordingData>(m_io->createArrayDataSet(
+      dataType, dsetSize, chunkSize, m_path + "/data"));
+  m_io->createDataAttributes(m_path, conversion, resolution, unit);
 
   SizeArray tsDsetSize = {
       dsetSize[0]};  // timestamps match data along first dimension
-  this->timestamps = std::unique_ptr<BaseRecordingData>(
-      this->m_io->createArrayDataSet(this->timestampsType,
-                                     tsDsetSize,
-                                     chunkSize,
-                                     this->m_path + "/timestamps"));
-  this->m_io->createTimestampsAttributes(this->m_path);
+  this->timestamps =
+      std::unique_ptr<BaseRecordingData>(m_io->createArrayDataSet(
+          this->timestampsType, tsDsetSize, chunkSize, m_path + "/timestamps"));
+  m_io->createTimestampsAttributes(m_path);
 }
 
 Status TimeSeries::writeData(const std::vector<SizeType>& dataShape,

--- a/src/nwb/base/TimeSeries.cpp
+++ b/src/nwb/base/TimeSeries.cpp
@@ -37,18 +37,23 @@ void TimeSeries::initialize()
   Container::initialize();
 
   // setup attributes
-  this->m_io->createCommonNWBAttributes(this->m_path, "core", neurodataType, description);
+  this->m_io->createCommonNWBAttributes(
+      this->m_path, "core", neurodataType, description);
   this->m_io->createAttribute(comments, this->m_path, "comments");
 
   // setup datasets
-  this->data = std::unique_ptr<BaseRecordingData>(this->m_io->createArrayDataSet(
-      dataType, dsetSize, chunkSize, this->m_path + "/data"));
+  this->data =
+      std::unique_ptr<BaseRecordingData>(this->m_io->createArrayDataSet(
+          dataType, dsetSize, chunkSize, this->m_path + "/data"));
   this->m_io->createDataAttributes(this->m_path, conversion, resolution, unit);
 
   SizeArray tsDsetSize = {
       dsetSize[0]};  // timestamps match data along first dimension
-  this->timestamps = std::unique_ptr<BaseRecordingData>(this->m_io->createArrayDataSet(
-      this->timestampsType, tsDsetSize, chunkSize, this->m_path + "/timestamps"));
+  this->timestamps = std::unique_ptr<BaseRecordingData>(
+      this->m_io->createArrayDataSet(this->timestampsType,
+                                     tsDsetSize,
+                                     chunkSize,
+                                     this->m_path + "/timestamps"));
   this->m_io->createTimestampsAttributes(this->m_path);
 }
 

--- a/src/nwb/base/TimeSeries.cpp
+++ b/src/nwb/base/TimeSeries.cpp
@@ -37,19 +37,19 @@ void TimeSeries::initialize()
   Container::initialize();
 
   // setup attributes
-  io->createCommonNWBAttributes(path, "core", neurodataType, description);
-  io->createAttribute(comments, path, "comments");
+  this->m_io->createCommonNWBAttributes(this->m_path, "core", neurodataType, description);
+  this->m_io->createAttribute(comments, this->m_path, "comments");
 
   // setup datasets
-  this->data = std::unique_ptr<BaseRecordingData>(io->createArrayDataSet(
-      dataType, dsetSize, chunkSize, getPath() + "/data"));
-  io->createDataAttributes(getPath(), conversion, resolution, unit);
+  this->data = std::unique_ptr<BaseRecordingData>(this->m_io->createArrayDataSet(
+      dataType, dsetSize, chunkSize, this->m_path + "/data"));
+  this->m_io->createDataAttributes(this->m_path, conversion, resolution, unit);
 
   SizeArray tsDsetSize = {
       dsetSize[0]};  // timestamps match data along first dimension
-  this->timestamps = std::unique_ptr<BaseRecordingData>(io->createArrayDataSet(
-      this->timestampsType, tsDsetSize, chunkSize, getPath() + "/timestamps"));
-  io->createTimestampsAttributes(getPath());
+  this->timestamps = std::unique_ptr<BaseRecordingData>(this->m_io->createArrayDataSet(
+      this->timestampsType, tsDsetSize, chunkSize, this->m_path + "/timestamps"));
+  this->m_io->createTimestampsAttributes(this->m_path);
 }
 
 Status TimeSeries::writeData(const std::vector<SizeType>& dataShape,

--- a/src/nwb/device/Device.cpp
+++ b/src/nwb/device/Device.cpp
@@ -21,9 +21,8 @@ void Device::initialize()
 {
   Container::initialize();
 
-  this->m_io->createCommonNWBAttributes(
-      this->m_path, "core", "Device", description);
-  this->m_io->createAttribute(manufacturer, this->m_path, "manufacturer");
+  m_io->createCommonNWBAttributes(m_path, "core", "Device", description);
+  m_io->createAttribute(manufacturer, m_path, "manufacturer");
 }
 
 // Getter for manufacturer

--- a/src/nwb/device/Device.cpp
+++ b/src/nwb/device/Device.cpp
@@ -21,7 +21,8 @@ void Device::initialize()
 {
   Container::initialize();
 
-  this->m_io->createCommonNWBAttributes(this->m_path, "core", "Device", description);
+  this->m_io->createCommonNWBAttributes(
+      this->m_path, "core", "Device", description);
   this->m_io->createAttribute(manufacturer, this->m_path, "manufacturer");
 }
 

--- a/src/nwb/device/Device.cpp
+++ b/src/nwb/device/Device.cpp
@@ -21,8 +21,8 @@ void Device::initialize()
 {
   Container::initialize();
 
-  io->createCommonNWBAttributes(path, "core", "Device", description);
-  io->createAttribute(manufacturer, path, "manufacturer");
+  this->m_io->createCommonNWBAttributes(this->m_path, "core", "Device", description);
+  this->m_io->createAttribute(manufacturer, this->m_path, "manufacturer");
 }
 
 // Getter for manufacturer

--- a/src/nwb/ecephys/ElectricalSeries.cpp
+++ b/src/nwb/ecephys/ElectricalSeries.cpp
@@ -52,32 +52,32 @@ void ElectricalSeries::initialize()
 
   // make channel conversion dataset
   channelConversion = std::unique_ptr<BaseRecordingData>(
-      this->m_io->createArrayDataSet(BaseDataType::F32,
-                                     SizeArray {1},
-                                     chunkSize,
-                                     getPath() + "/channel_conversion"));
+      m_io->createArrayDataSet(BaseDataType::F32,
+                               SizeArray {1},
+                               chunkSize,
+                               getPath() + "/channel_conversion"));
   channelConversion->writeDataBlock(
       std::vector<SizeType>(1, channelVector.size()),
       BaseDataType::F32,
       &channelConversions[0]);
-  this->m_io->createCommonNWBAttributes(getPath() + "/channel_conversion",
-                                        "hdmf-common",
-                                        "",
-                                        "Bit volts values for all channels");
+  m_io->createCommonNWBAttributes(getPath() + "/channel_conversion",
+                                  "hdmf-common",
+                                  "",
+                                  "Bit volts values for all channels");
 
   // make electrodes dataset
   electrodesDataset = std::unique_ptr<BaseRecordingData>(
-      this->m_io->createArrayDataSet(BaseDataType::I32,
-                                     SizeArray {1},
-                                     chunkSize,
-                                     getPath() + "/electrodes"));
+      m_io->createArrayDataSet(BaseDataType::I32,
+                               SizeArray {1},
+                               chunkSize,
+                               getPath() + "/electrodes"));
   electrodesDataset->writeDataBlock(
       std::vector<SizeType>(1, channelVector.size()),
       BaseDataType::I32,
       &electrodeInds[0]);
-  this->m_io->createCommonNWBAttributes(
+  m_io->createCommonNWBAttributes(
       getPath() + "/electrodes", "hdmf-common", "DynamicTableRegion", "");
-  this->m_io->createReferenceAttribute(
+  m_io->createReferenceAttribute(
       ElectrodeTable::electrodeTablePath, getPath() + "/electrodes", "table");
 }
 

--- a/src/nwb/ecephys/ElectricalSeries.cpp
+++ b/src/nwb/ecephys/ElectricalSeries.cpp
@@ -23,7 +23,7 @@ ElectricalSeries::ElectricalSeries(const std::string& path,
                  dataType,
                  "volts",  // default unit for Electrical Series
                  description,
-                 channelVector[0].comments,
+                 channelVector[0].getComments(),
                  dsetSize,
                  chunkSize,
                  channelVector[0].getConversion(),
@@ -45,7 +45,7 @@ void ElectricalSeries::initialize()
   std::vector<int> electrodeInds(channelVector.size());
   std::vector<float> channelConversions(channelVector.size());
   for (size_t i = 0; i < channelVector.size(); ++i) {
-    electrodeInds[i] = channelVector[i].globalIndex;
+    electrodeInds[i] = channelVector[i].getGlobalIndex();
     channelConversions[i] = channelVector[i].getConversion();
   }
   samplesRecorded = SizeArray(channelVector.size(), 0);

--- a/src/nwb/ecephys/ElectricalSeries.cpp
+++ b/src/nwb/ecephys/ElectricalSeries.cpp
@@ -53,21 +53,24 @@ void ElectricalSeries::initialize()
   // make channel conversion dataset
   channelConversion = std::unique_ptr<BaseRecordingData>(
       this->m_io->createArrayDataSet(BaseDataType::F32,
-                             SizeArray {1},
-                             chunkSize,
-                             getPath() + "/channel_conversion"));
+                                     SizeArray {1},
+                                     chunkSize,
+                                     getPath() + "/channel_conversion"));
   channelConversion->writeDataBlock(
       std::vector<SizeType>(1, channelVector.size()),
       BaseDataType::F32,
       &channelConversions[0]);
   this->m_io->createCommonNWBAttributes(getPath() + "/channel_conversion",
-                                "hdmf-common",
-                                "",
-                                "Bit volts values for all channels");
+                                        "hdmf-common",
+                                        "",
+                                        "Bit volts values for all channels");
 
   // make electrodes dataset
-  electrodesDataset = std::unique_ptr<BaseRecordingData>(this->m_io->createArrayDataSet(
-      BaseDataType::I32, SizeArray {1}, chunkSize, getPath() + "/electrodes"));
+  electrodesDataset = std::unique_ptr<BaseRecordingData>(
+      this->m_io->createArrayDataSet(BaseDataType::I32,
+                                     SizeArray {1},
+                                     chunkSize,
+                                     getPath() + "/electrodes"));
   electrodesDataset->writeDataBlock(
       std::vector<SizeType>(1, channelVector.size()),
       BaseDataType::I32,

--- a/src/nwb/ecephys/ElectricalSeries.cpp
+++ b/src/nwb/ecephys/ElectricalSeries.cpp
@@ -52,7 +52,7 @@ void ElectricalSeries::initialize()
 
   // make channel conversion dataset
   channelConversion = std::unique_ptr<BaseRecordingData>(
-      io->createArrayDataSet(BaseDataType::F32,
+      this->m_io->createArrayDataSet(BaseDataType::F32,
                              SizeArray {1},
                              chunkSize,
                              getPath() + "/channel_conversion"));
@@ -60,21 +60,21 @@ void ElectricalSeries::initialize()
       std::vector<SizeType>(1, channelVector.size()),
       BaseDataType::F32,
       &channelConversions[0]);
-  io->createCommonNWBAttributes(getPath() + "/channel_conversion",
+  this->m_io->createCommonNWBAttributes(getPath() + "/channel_conversion",
                                 "hdmf-common",
                                 "",
                                 "Bit volts values for all channels");
 
   // make electrodes dataset
-  electrodesDataset = std::unique_ptr<BaseRecordingData>(io->createArrayDataSet(
+  electrodesDataset = std::unique_ptr<BaseRecordingData>(this->m_io->createArrayDataSet(
       BaseDataType::I32, SizeArray {1}, chunkSize, getPath() + "/electrodes"));
   electrodesDataset->writeDataBlock(
       std::vector<SizeType>(1, channelVector.size()),
       BaseDataType::I32,
       &electrodeInds[0]);
-  io->createCommonNWBAttributes(
+  this->m_io->createCommonNWBAttributes(
       getPath() + "/electrodes", "hdmf-common", "DynamicTableRegion", "");
-  io->createReferenceAttribute(
+  this->m_io->createReferenceAttribute(
       ElectrodeTable::electrodeTablePath, getPath() + "/electrodes", "table");
 }
 

--- a/src/nwb/ecephys/SpikeEventSeries.hpp
+++ b/src/nwb/ecephys/SpikeEventSeries.hpp
@@ -17,10 +17,24 @@ class SpikeEventSeries : public ElectricalSeries
 public:
   /**
    * @brief Constructor.
-   * @param path The location of the SpikeEventSeries in the file.
+   * @param path The location of the ElectricalSeries in the file.
    * @param io A shared pointer to the IO object.
-   * @param description The description of the SpikeEventSeries, should describe
-   * how events were detected.
+   * @param dataType The data type to use for storing the recorded voltage
+   * @param channelVector The electrodes to use for recording
+   * @param description The description of the TimeSeries.
+   * @param dsetSize Initial size of the main dataset. This must be a vector
+   *                 with two elements. The first element specifies the length
+   *                 in time and the second element must be equal to the
+   *                 length of channelVector
+   * @param chunkSize Chunk size to use. The number of elements must be two to
+   *                  specify the size of a chunk in the time and electrode
+   *                  dimension
+   * @param conversion Scalar to multiply each element in data to convert it to
+   *                   the specified ‘unit’
+   * @param resolution Smallest meaningful difference between values in data,
+   *                   stored in the specified by unit
+   * @param offset Scalar to add to the data after scaling by ‘conversion’ to
+   *               finalize its coercion to the specified ‘unit'
    */
   SpikeEventSeries(const std::string& path,
                    std::shared_ptr<BaseIO> io,
@@ -49,7 +63,6 @@ public:
    * @param numChannels The number of channels in the event
    * @param data The data of the event
    * @param timestamps The timestamps of the event
-   * @param
    */
   Status writeSpike(const SizeType& numSamples,
                     const SizeType& numChannels,

--- a/src/nwb/file/ElectrodeGroup.cpp
+++ b/src/nwb/file/ElectrodeGroup.cpp
@@ -24,11 +24,10 @@ void ElectrodeGroup::initialize()
 {
   Container::initialize();
 
-  this->m_io->createCommonNWBAttributes(
-      this->m_path, "core", "ElectrodeGroup", description);
-  this->m_io->createAttribute(location, this->m_path, "location");
-  this->m_io->createLink("/" + this->m_path + "/device",
-                         "/" + device.getPath());
+  m_io->createCommonNWBAttributes(
+      m_path, "core", "ElectrodeGroup", description);
+  m_io->createAttribute(location, m_path, "location");
+  m_io->createLink("/" + m_path + "/device", "/" + device.getPath());
 }
 
 // Getter for description

--- a/src/nwb/file/ElectrodeGroup.cpp
+++ b/src/nwb/file/ElectrodeGroup.cpp
@@ -24,9 +24,9 @@ void ElectrodeGroup::initialize()
 {
   Container::initialize();
 
-  io->createCommonNWBAttributes(path, "core", "ElectrodeGroup", description);
-  io->createAttribute(location, path, "location");
-  io->createLink("/" + path + "/device", "/" + device.getPath());
+  this->m_io->createCommonNWBAttributes(this->m_path, "core", "ElectrodeGroup", description);
+  this->m_io->createAttribute(location, this->m_path, "location");
+  this->m_io->createLink("/" + this->m_path + "/device", "/" + device.getPath());
 }
 
 // Getter for description

--- a/src/nwb/file/ElectrodeGroup.cpp
+++ b/src/nwb/file/ElectrodeGroup.cpp
@@ -24,9 +24,11 @@ void ElectrodeGroup::initialize()
 {
   Container::initialize();
 
-  this->m_io->createCommonNWBAttributes(this->m_path, "core", "ElectrodeGroup", description);
+  this->m_io->createCommonNWBAttributes(
+      this->m_path, "core", "ElectrodeGroup", description);
   this->m_io->createAttribute(location, this->m_path, "location");
-  this->m_io->createLink("/" + this->m_path + "/device", "/" + device.getPath());
+  this->m_io->createLink("/" + this->m_path + "/device",
+                         "/" + device.getPath());
 }
 
 // Getter for description

--- a/src/nwb/file/ElectrodeTable.cpp
+++ b/src/nwb/file/ElectrodeTable.cpp
@@ -41,9 +41,9 @@ void ElectrodeTable::addElectrodes(std::vector<Channel> channels)
 {
   // create datasets
   for (const auto& ch : channels) {
-    groupReferences.push_back(groupPathBase + ch.groupName);
-    groupNames.push_back(ch.groupName);
-    electrodeNumbers.push_back(ch.globalIndex);
+    groupReferences.push_back(groupPathBase + ch.getGroupName());
+    groupNames.push_back(ch.getGroupName());
+    electrodeNumbers.push_back(ch.getGlobalIndex());
     locationNames.push_back("unknown");
   }
 }

--- a/src/nwb/file/ElectrodeTable.cpp
+++ b/src/nwb/file/ElectrodeTable.cpp
@@ -24,21 +24,21 @@ void ElectrodeTable::initialize()
   // create group
   DynamicTable::initialize();
 
-  electrodeDataset->dataset = std::unique_ptr<BaseRecordingData>(
+  electrodeDataset->setDataset(std::unique_ptr<BaseRecordingData>(
       this->m_io->createArrayDataSet(BaseDataType::I32,
                                      SizeArray {1},
                                      SizeArray {1},
-                                     this->m_path + "id"));
-  groupNamesDataset->dataset = std::unique_ptr<BaseRecordingData>(
+                                     this->m_path + "id")));
+  groupNamesDataset->setDataset(std::unique_ptr<BaseRecordingData>(
       this->m_io->createArrayDataSet(BaseDataType::STR(250),
                                      SizeArray {0},
                                      SizeArray {1},
-                                     this->m_path + "group_name"));
-  locationsDataset->dataset = std::unique_ptr<BaseRecordingData>(
+                                     this->m_path + "group_name")));
+  locationsDataset->setDataset(std::unique_ptr<BaseRecordingData>(
       this->m_io->createArrayDataSet(BaseDataType::STR(250),
                                      SizeArray {0},
                                      SizeArray {1},
-                                     this->m_path + "location"));
+                                     this->m_path + "location")));
 }
 
 void ElectrodeTable::addElectrodes(std::vector<Channel> channels)

--- a/src/nwb/file/ElectrodeTable.cpp
+++ b/src/nwb/file/ElectrodeTable.cpp
@@ -24,21 +24,19 @@ void ElectrodeTable::initialize()
   // create group
   DynamicTable::initialize();
 
-  electrodeDataset->setDataset(std::unique_ptr<BaseRecordingData>(
-      this->m_io->createArrayDataSet(BaseDataType::I32,
-                                     SizeArray {1},
-                                     SizeArray {1},
-                                     this->m_path + "id")));
+  electrodeDataset->setDataset(
+      std::unique_ptr<BaseRecordingData>(m_io->createArrayDataSet(
+          BaseDataType::I32, SizeArray {1}, SizeArray {1}, m_path + "id")));
   groupNamesDataset->setDataset(std::unique_ptr<BaseRecordingData>(
-      this->m_io->createArrayDataSet(BaseDataType::STR(250),
-                                     SizeArray {0},
-                                     SizeArray {1},
-                                     this->m_path + "group_name")));
+      m_io->createArrayDataSet(BaseDataType::STR(250),
+                               SizeArray {0},
+                               SizeArray {1},
+                               m_path + "group_name")));
   locationsDataset->setDataset(std::unique_ptr<BaseRecordingData>(
-      this->m_io->createArrayDataSet(BaseDataType::STR(250),
-                                     SizeArray {0},
-                                     SizeArray {1},
-                                     this->m_path + "location")));
+      m_io->createArrayDataSet(BaseDataType::STR(250),
+                               SizeArray {0},
+                               SizeArray {1},
+                               m_path + "location")));
 }
 
 void ElectrodeTable::addElectrodes(std::vector<Channel> channels)

--- a/src/nwb/file/ElectrodeTable.cpp
+++ b/src/nwb/file/ElectrodeTable.cpp
@@ -24,17 +24,21 @@ void ElectrodeTable::initialize()
   // create group
   DynamicTable::initialize();
 
-  electrodeDataset->dataset =
-      std::unique_ptr<BaseRecordingData>(this->m_io->createArrayDataSet(
-          BaseDataType::I32, SizeArray {1}, SizeArray {1}, this->m_path + "id"));
+  electrodeDataset->dataset = std::unique_ptr<BaseRecordingData>(
+      this->m_io->createArrayDataSet(BaseDataType::I32,
+                                     SizeArray {1},
+                                     SizeArray {1},
+                                     this->m_path + "id"));
   groupNamesDataset->dataset = std::unique_ptr<BaseRecordingData>(
       this->m_io->createArrayDataSet(BaseDataType::STR(250),
-                             SizeArray {0},
-                             SizeArray {1},
-                             this->m_path + "group_name"));
-  locationsDataset
-      ->dataset = std::unique_ptr<BaseRecordingData>(this->m_io->createArrayDataSet(
-      BaseDataType::STR(250), SizeArray {0}, SizeArray {1}, this->m_path + "location"));
+                                     SizeArray {0},
+                                     SizeArray {1},
+                                     this->m_path + "group_name"));
+  locationsDataset->dataset = std::unique_ptr<BaseRecordingData>(
+      this->m_io->createArrayDataSet(BaseDataType::STR(250),
+                                     SizeArray {0},
+                                     SizeArray {1},
+                                     this->m_path + "location"));
 }
 
 void ElectrodeTable::addElectrodes(std::vector<Channel> channels)

--- a/src/nwb/file/ElectrodeTable.cpp
+++ b/src/nwb/file/ElectrodeTable.cpp
@@ -65,22 +65,3 @@ void ElectrodeTable::finalize()
             "a reference to the ElectrodeGroup this electrode is a part of",
             groupReferences);
 }
-
-// Getter for colNames
-const std::vector<std::string>& ElectrodeTable::getColNames()
-{
-  return colNames;
-}
-
-// Setter for colNames
-void ElectrodeTable::setColNames(const std::vector<std::string>& newColNames)
-{
-  colNames = newColNames;
-}
-
-// Getter for groupPath
-std::string ElectrodeTable::getGroupPath() const
-{
-  return groupReferences[0];  // all channels in ChannelVector should have the
-                              // same groupName
-}

--- a/src/nwb/file/ElectrodeTable.cpp
+++ b/src/nwb/file/ElectrodeTable.cpp
@@ -11,7 +11,8 @@ ElectrodeTable::ElectrodeTable(std::shared_ptr<BaseIO> io,
                                const std::string& description)
     : DynamicTable(electrodeTablePath,  // use the electrodeTablePath
                    io,
-                   description)
+                   description,
+                   {"group", "group_name", "location"})
 {
 }
 

--- a/src/nwb/file/ElectrodeTable.cpp
+++ b/src/nwb/file/ElectrodeTable.cpp
@@ -25,16 +25,16 @@ void ElectrodeTable::initialize()
   DynamicTable::initialize();
 
   electrodeDataset->dataset =
-      std::unique_ptr<BaseRecordingData>(io->createArrayDataSet(
-          BaseDataType::I32, SizeArray {1}, SizeArray {1}, path + "id"));
+      std::unique_ptr<BaseRecordingData>(this->m_io->createArrayDataSet(
+          BaseDataType::I32, SizeArray {1}, SizeArray {1}, this->m_path + "id"));
   groupNamesDataset->dataset = std::unique_ptr<BaseRecordingData>(
-      io->createArrayDataSet(BaseDataType::STR(250),
+      this->m_io->createArrayDataSet(BaseDataType::STR(250),
                              SizeArray {0},
                              SizeArray {1},
-                             path + "group_name"));
+                             this->m_path + "group_name"));
   locationsDataset
-      ->dataset = std::unique_ptr<BaseRecordingData>(io->createArrayDataSet(
-      BaseDataType::STR(250), SizeArray {0}, SizeArray {1}, path + "location"));
+      ->dataset = std::unique_ptr<BaseRecordingData>(this->m_io->createArrayDataSet(
+      BaseDataType::STR(250), SizeArray {0}, SizeArray {1}, this->m_path + "location"));
 }
 
 void ElectrodeTable::addElectrodes(std::vector<Channel> channels)

--- a/src/nwb/file/ElectrodeTable.hpp
+++ b/src/nwb/file/ElectrodeTable.hpp
@@ -108,11 +108,6 @@ private:
   std::vector<std::string> groupReferences;
 
   /**
-   * @brief The vector of column names for the table.
-   */
-  std::vector<std::string> colNames = {"group", "group_name", "location"};
-
-  /**
    * @brief The references path to the ElectrodeGroup
    */
   std::string groupPathBase = "/general/extracellular_ephys/";

--- a/src/nwb/file/ElectrodeTable.hpp
+++ b/src/nwb/file/ElectrodeTable.hpp
@@ -53,22 +53,14 @@ public:
   void addElectrodes(std::vector<Channel> channels);
 
   /**
-   * @brief Gets the column names of the ElectrodeTable.
-   * @return The vector of column names.
-   */
-  const std::vector<std::string>& getColNames() override;
-
-  /**
-   * @brief Sets the column names of the ElectrodeTable.
-   * @param newColNames The vector of new column names.
-   */
-  void setColNames(const std::vector<std::string>& newColNames);
-
-  /**
    * @brief Gets the group path of the ElectrodeTable.
    * @return The group path.
    */
-  std::string getGroupPath() const;
+  inline std::string getGroupPath() const
+  {
+    // all channels in ChannelVector should have the same groupName
+    return groupReferences[0];
+  }
 
   /**
    * @brief Sets the group path of the ElectrodeTable.

--- a/src/nwb/hdmf/base/Container.cpp
+++ b/src/nwb/hdmf/base/Container.cpp
@@ -6,8 +6,8 @@ using namespace AQNWB::NWB;
 
 /** Constructor */
 Container::Container(const std::string& path, std::shared_ptr<BaseIO> io)
-    : path(path)
-    , io(io)
+    : m_path(path)
+    , m_io(io)
 {
 }
 
@@ -17,11 +17,5 @@ Container::~Container() {}
 /** Initialize */
 void Container::initialize()
 {
-  io->createGroup(path);
-}
-
-/** Getter for path */
-std::string Container::getPath() const
-{
-  return path;
+  m_io->createGroup(m_path);
 }

--- a/src/nwb/hdmf/base/Container.hpp
+++ b/src/nwb/hdmf/base/Container.hpp
@@ -35,17 +35,17 @@ public:
    * @brief Gets the path of the container.
    * @return The path of the container.
    */
-  std::string getPath() const;
+  inline std::string getPath() const { return m_path; }
 
 protected:
   /**
    * @brief The path of the container.
    */
-  std::string path;
+  std::string m_path;
 
   /**
    * @brief A shared pointer to the IO object.
    */
-  std::shared_ptr<BaseIO> io;
+  std::shared_ptr<BaseIO> m_io;
 };
 }  // namespace AQNWB::NWB

--- a/src/nwb/hdmf/base/Data.hpp
+++ b/src/nwb/hdmf/base/Data.hpp
@@ -23,8 +23,23 @@ public:
   ~Data() {}
 
   /**
-   * @brief Pointer to dataset.
+   *  @brief Initialize the dataset for the Data object
+   *
+   *  This functions takes ownership of the passed rvalue unique_ptr and moves
+   *  ownership to its internal m_dataset variable
+   *
+   * @param The rvalue unique pointer to the BaseRecordingData object
    */
-  std::unique_ptr<BaseRecordingData> dataset;
+  inline void setDataset(std::unique_ptr<BaseRecordingData>&& dataset)
+  {
+    m_dataset = std::move(dataset);
+  }
+
+  /**
+   * @brief Check whether the m_dataset has been initialized
+   */
+  inline bool isInitialized() { return this->m_dataset != nullptr; }
+
+  std::unique_ptr<BaseRecordingData> m_dataset;
 };
 }  // namespace AQNWB::NWB

--- a/src/nwb/hdmf/base/Data.hpp
+++ b/src/nwb/hdmf/base/Data.hpp
@@ -28,7 +28,7 @@ public:
    *  This functions takes ownership of the passed rvalue unique_ptr and moves
    *  ownership to its internal m_dataset variable
    *
-   * @param The rvalue unique pointer to the BaseRecordingData object
+   * @param dataset The rvalue unique pointer to the BaseRecordingData object
    */
   inline void setDataset(std::unique_ptr<BaseRecordingData>&& dataset)
   {

--- a/src/nwb/hdmf/base/Data.hpp
+++ b/src/nwb/hdmf/base/Data.hpp
@@ -38,7 +38,7 @@ public:
   /**
    * @brief Check whether the m_dataset has been initialized
    */
-  inline bool isInitialized() { return this->m_dataset != nullptr; }
+  inline bool isInitialized() { return m_dataset != nullptr; }
 
   std::unique_ptr<BaseRecordingData> m_dataset;
 };

--- a/src/nwb/hdmf/table/DynamicTable.cpp
+++ b/src/nwb/hdmf/table/DynamicTable.cpp
@@ -7,9 +7,11 @@ using namespace AQNWB::NWB;
 /** Constructor */
 DynamicTable::DynamicTable(const std::string& path,
                            std::shared_ptr<BaseIO> io,
-                           const std::string& description)
+                           const std::string& description,
+                           const std::vector<std::string>& colNames)
     : Container(path, io)
     , m_description(description)
+    , m_colNames(colNames)
 {
 }
 

--- a/src/nwb/hdmf/table/DynamicTable.cpp
+++ b/src/nwb/hdmf/table/DynamicTable.cpp
@@ -32,12 +32,12 @@ void DynamicTable::addColumn(const std::string& name,
                              std::unique_ptr<VectorData>& vectorData,
                              const std::vector<std::string>& values)
 {
-  if (vectorData->dataset == nullptr) {
+  if (!vectorData->isInitialized()) {
     std::cerr << "VectorData dataset is not initialized" << std::endl;
   } else {
     // write in loop because variable length string
     for (SizeType i = 0; i < values.size(); i++)
-      vectorData->dataset->writeDataBlock(
+      vectorData->m_dataset->writeDataBlock(
           std::vector<SizeType>(1, 1),
           BaseDataType::STR(values[i].size() + 1),
           values[i].c_str());  // TODO - add tests for this
@@ -49,10 +49,10 @@ void DynamicTable::addColumn(const std::string& name,
 void DynamicTable::setRowIDs(std::unique_ptr<ElementIdentifiers>& elementIDs,
                              const std::vector<int>& values)
 {
-  if (elementIDs->dataset == nullptr) {
+  if (!elementIDs->isInitialized()) {
     std::cerr << "ElementIdentifiers dataset is not initialized" << std::endl;
   } else {
-    elementIDs->dataset->writeDataBlock(
+    elementIDs->m_dataset->writeDataBlock(
         std::vector<SizeType>(1, values.size()), BaseDataType::I32, &values[0]);
     this->m_io->createCommonNWBAttributes(
         this->m_path + "id", "hdmf-common", "ElementIdentifiers");

--- a/src/nwb/hdmf/table/DynamicTable.cpp
+++ b/src/nwb/hdmf/table/DynamicTable.cpp
@@ -21,9 +21,9 @@ void DynamicTable::initialize()
 {
   Container::initialize();
 
-  io->createCommonNWBAttributes(
-      path, "hdmf-common", "DynamicTable", getDescription());
-  io->createAttribute(getColNames(), path, "colnames");
+  this->m_io->createCommonNWBAttributes(
+      this->m_path, "hdmf-common", "DynamicTable", getDescription());
+  this->m_io->createAttribute(getColNames(), this->m_path, "colnames");
 }
 
 /** Add column to table */
@@ -41,8 +41,8 @@ void DynamicTable::addColumn(const std::string& name,
           std::vector<SizeType>(1, 1),
           BaseDataType::STR(values[i].size() + 1),
           values[i].c_str());  // TODO - add tests for this
-    io->createCommonNWBAttributes(
-        path + name, "hdmf-common", "VectorData", colDescription);
+    this->m_io->createCommonNWBAttributes(
+        this->m_path + name, "hdmf-common", "VectorData", colDescription);
   }
 }
 
@@ -54,8 +54,8 @@ void DynamicTable::setRowIDs(std::unique_ptr<ElementIdentifiers>& elementIDs,
   } else {
     elementIDs->dataset->writeDataBlock(
         std::vector<SizeType>(1, values.size()), BaseDataType::I32, &values[0]);
-    io->createCommonNWBAttributes(
-        path + "id", "hdmf-common", "ElementIdentifiers");
+    this->m_io->createCommonNWBAttributes(
+        this->m_path + "id", "hdmf-common", "ElementIdentifiers");
   }
 }
 
@@ -66,9 +66,9 @@ void DynamicTable::addColumn(const std::string& name,
   if (values.empty()) {
     std::cerr << "Data to add to column is empty" << std::endl;
   } else {
-    io->createReferenceDataSet(path + name, values);
-    io->createCommonNWBAttributes(
-        path + name, "hdmf-common", "VectorData", colDescription);
+    this->m_io->createReferenceDataSet(this->m_path + name, values);
+    this->m_io->createCommonNWBAttributes(
+        this->m_path + name, "hdmf-common", "VectorData", colDescription);
   }
 }
 

--- a/src/nwb/hdmf/table/DynamicTable.cpp
+++ b/src/nwb/hdmf/table/DynamicTable.cpp
@@ -9,7 +9,7 @@ DynamicTable::DynamicTable(const std::string& path,
                            std::shared_ptr<BaseIO> io,
                            const std::string& description)
     : Container(path, io)
-    , description(description)
+    , m_description(description)
 {
 }
 
@@ -70,16 +70,4 @@ void DynamicTable::addColumn(const std::string& name,
     m_io->createCommonNWBAttributes(
         m_path + name, "hdmf-common", "VectorData", colDescription);
   }
-}
-
-// Getter for description
-std::string DynamicTable::getDescription() const
-{
-  return description;
-}
-
-// Getter for colNames
-const std::vector<std::string>& DynamicTable::getColNames()
-{
-  return colNames;
 }

--- a/src/nwb/hdmf/table/DynamicTable.cpp
+++ b/src/nwb/hdmf/table/DynamicTable.cpp
@@ -21,9 +21,9 @@ void DynamicTable::initialize()
 {
   Container::initialize();
 
-  this->m_io->createCommonNWBAttributes(
-      this->m_path, "hdmf-common", "DynamicTable", getDescription());
-  this->m_io->createAttribute(getColNames(), this->m_path, "colnames");
+  m_io->createCommonNWBAttributes(
+      m_path, "hdmf-common", "DynamicTable", getDescription());
+  m_io->createAttribute(getColNames(), m_path, "colnames");
 }
 
 /** Add column to table */
@@ -41,8 +41,8 @@ void DynamicTable::addColumn(const std::string& name,
           std::vector<SizeType>(1, 1),
           BaseDataType::STR(values[i].size() + 1),
           values[i].c_str());  // TODO - add tests for this
-    this->m_io->createCommonNWBAttributes(
-        this->m_path + name, "hdmf-common", "VectorData", colDescription);
+    m_io->createCommonNWBAttributes(
+        m_path + name, "hdmf-common", "VectorData", colDescription);
   }
 }
 
@@ -54,8 +54,8 @@ void DynamicTable::setRowIDs(std::unique_ptr<ElementIdentifiers>& elementIDs,
   } else {
     elementIDs->m_dataset->writeDataBlock(
         std::vector<SizeType>(1, values.size()), BaseDataType::I32, &values[0]);
-    this->m_io->createCommonNWBAttributes(
-        this->m_path + "id", "hdmf-common", "ElementIdentifiers");
+    m_io->createCommonNWBAttributes(
+        m_path + "id", "hdmf-common", "ElementIdentifiers");
   }
 }
 
@@ -66,9 +66,9 @@ void DynamicTable::addColumn(const std::string& name,
   if (values.empty()) {
     std::cerr << "Data to add to column is empty" << std::endl;
   } else {
-    this->m_io->createReferenceDataSet(this->m_path + name, values);
-    this->m_io->createCommonNWBAttributes(
-        this->m_path + name, "hdmf-common", "VectorData", colDescription);
+    m_io->createReferenceDataSet(m_path + name, values);
+    m_io->createCommonNWBAttributes(
+        m_path + name, "hdmf-common", "VectorData", colDescription);
   }
 }
 

--- a/src/nwb/hdmf/table/DynamicTable.hpp
+++ b/src/nwb/hdmf/table/DynamicTable.hpp
@@ -27,7 +27,8 @@ public:
    */
   DynamicTable(const std::string& path,
                std::shared_ptr<BaseIO> io,
-               const std::string& description);
+               const std::string& description,
+               const std::vector<std::string>& colNames);
 
   /**
    * @brief Destructor
@@ -94,7 +95,7 @@ public:
     m_colNames = newColNames;
   }
 
-private:
+protected:
   /**
    * @brief Description of the DynamicTable.
    */

--- a/src/nwb/hdmf/table/DynamicTable.hpp
+++ b/src/nwb/hdmf/table/DynamicTable.hpp
@@ -74,23 +74,35 @@ public:
    * @brief Gets the description of the table.
    * @return The description of the table.
    */
-  std::string getDescription() const;
+  inline std::string getDescription() const { return m_description; }
 
   /**
    * @brief Gets the column names of the table.
    * @return A vector of column names.
    */
-  virtual const std::vector<std::string>& getColNames() = 0;
+  virtual const std::vector<std::string>& getColNames() const
+  {
+    return m_colNames;
+  }
+
+  /**
+   * @brief Sets the column names of the ElectrodeTable.
+   * @param newColNames The vector of new column names.
+   */
+  virtual void setColNames(const std::vector<std::string>& newColNames)
+  {
+    m_colNames = newColNames;
+  }
 
 private:
   /**
    * @brief Description of the DynamicTable.
    */
-  std::string description;
+  std::string m_description;
 
   /**
    * @brief Names of the columns in the table.
    */
-  std::vector<std::string> colNames;
+  std::vector<std::string> m_colNames;
 };
 }  // namespace AQNWB::NWB

--- a/src/nwb/hdmf/table/VectorData.cpp
+++ b/src/nwb/hdmf/table/VectorData.cpp
@@ -1,9 +1,3 @@
 #include "nwb/hdmf/table/VectorData.hpp"
 
 using namespace AQNWB::NWB;
-
-// VectorData
-std::string VectorData::getDescription() const
-{
-  return m_description;
-}

--- a/src/nwb/hdmf/table/VectorData.cpp
+++ b/src/nwb/hdmf/table/VectorData.cpp
@@ -5,5 +5,5 @@ using namespace AQNWB::NWB;
 // VectorData
 std::string VectorData::getDescription() const
 {
-  return description;
+  return m_description;
 }

--- a/src/nwb/hdmf/table/VectorData.hpp
+++ b/src/nwb/hdmf/table/VectorData.hpp
@@ -22,6 +22,6 @@ private:
   /**
    * @brief Description of VectorData.
    */
-  std::string description;
+  std::string m_description;
 };
 }  // namespace AQNWB::NWB

--- a/src/nwb/hdmf/table/VectorData.hpp
+++ b/src/nwb/hdmf/table/VectorData.hpp
@@ -16,7 +16,7 @@ public:
    * @brief Gets the description of the table.
    * @return The description of the table.
    */
-  std::string getDescription() const;
+  inline std::string getDescription() const { return m_description; }
 
 private:
   /**

--- a/tests/examples/testWorkflowExamples.cpp
+++ b/tests/examples/testWorkflowExamples.cpp
@@ -70,10 +70,11 @@ TEST_CASE("workflowExamples")
         const auto& channelVector = mockRecordingArrays[i];
         for (const auto& channel : channelVector) {
           // copy data into buffer
-          std::copy(mockData[channel.getGlobalIndex()].begin() + samplesRecorded,
-                    mockData[channel.getGlobalIndex()].begin() + samplesRecorded
-                        + bufferSize,
-                    dataBuffer.begin());
+          std::copy(
+              mockData[channel.getGlobalIndex()].begin() + samplesRecorded,
+              mockData[channel.getGlobalIndex()].begin() + samplesRecorded
+                  + bufferSize,
+              dataBuffer.begin());
           std::copy(mockTimestamps.begin() + samplesRecorded,
                     mockTimestamps.begin() + samplesRecorded + bufferSize,
                     timestampsBuffer.begin());

--- a/tests/examples/testWorkflowExamples.cpp
+++ b/tests/examples/testWorkflowExamples.cpp
@@ -70,8 +70,8 @@ TEST_CASE("workflowExamples")
         const auto& channelVector = mockRecordingArrays[i];
         for (const auto& channel : channelVector) {
           // copy data into buffer
-          std::copy(mockData[channel.globalIndex].begin() + samplesRecorded,
-                    mockData[channel.globalIndex].begin() + samplesRecorded
+          std::copy(mockData[channel.getGlobalIndex()].begin() + samplesRecorded,
+                    mockData[channel.getGlobalIndex()].begin() + samplesRecorded
                         + bufferSize,
                     dataBuffer.begin());
           std::copy(mockTimestamps.begin() + samplesRecorded,
@@ -80,7 +80,7 @@ TEST_CASE("workflowExamples")
 
           // write timeseries data
           std::vector<SizeType> positionOffset = {samplesRecorded,
-                                                  channel.localIndex};
+                                                  channel.getLocalIndex()};
           std::vector<SizeType> dataShape = {dataBuffer.size(), 1};
           std::unique_ptr<int16_t[]> intBuffer = transformToInt16(
               dataBuffer.size(), channel.getBitVolts(), dataBuffer.data());

--- a/tests/testRecordingWorkflow.cpp
+++ b/tests/testRecordingWorkflow.cpp
@@ -65,8 +65,8 @@ TEST_CASE("writeContinuousData", "[recording]")
         const auto& channelVector = mockRecordingArrays[i];
         for (const auto& channel : channelVector) {
           // copy data into buffer
-          std::copy(mockData[channel.globalIndex].begin() + samplesRecorded,
-                    mockData[channel.globalIndex].begin() + samplesRecorded
+          std::copy(mockData[channel.getGlobalIndex()].begin() + samplesRecorded,
+                    mockData[channel.getGlobalIndex()].begin() + samplesRecorded
                         + bufferSize,
                     dataBuffer.begin());
           std::copy(mockTimestamps.begin() + samplesRecorded,
@@ -75,7 +75,7 @@ TEST_CASE("writeContinuousData", "[recording]")
 
           // write timeseries data
           std::vector<SizeType> positionOffset = {samplesRecorded,
-                                                  channel.localIndex};
+                                                  channel.getLocalIndex()};
           std::vector<SizeType> dataShape = {dataBuffer.size(), 1};
 
           recordingContainers->writeTimeseriesData(i,

--- a/tests/testRecordingWorkflow.cpp
+++ b/tests/testRecordingWorkflow.cpp
@@ -65,10 +65,11 @@ TEST_CASE("writeContinuousData", "[recording]")
         const auto& channelVector = mockRecordingArrays[i];
         for (const auto& channel : channelVector) {
           // copy data into buffer
-          std::copy(mockData[channel.getGlobalIndex()].begin() + samplesRecorded,
-                    mockData[channel.getGlobalIndex()].begin() + samplesRecorded
-                        + bufferSize,
-                    dataBuffer.begin());
+          std::copy(
+              mockData[channel.getGlobalIndex()].begin() + samplesRecorded,
+              mockData[channel.getGlobalIndex()].begin() + samplesRecorded
+                  + bufferSize,
+              dataBuffer.begin());
           std::copy(mockTimestamps.begin() + samplesRecorded,
                     mockTimestamps.begin() + samplesRecorded + bufferSize,
                     timestampsBuffer.begin());


### PR DESCRIPTION
Fix #60
Fix #9
Fix #106

- [X] Container
- [X] Data
- [X] NWBFile
- [X] RecordingContainers
- [X] Channel
- [X] VectorData  
- [X] ElementIdentifiers (noop)
- [x] HDF5RecordingData
- [x] HDF5IO
- [x] BaseIO
- [x] DynamicTable

**To be fixed in read I/O PR #85**
- [ ] ElectrodeTable 
- [ ] ElectrodeGroup
- [ ] SpikeEventSeries
- [ ] ElectricalSeries
- [ ] Device
- [ ] TimeSeries (already fixed in #85)