### PR TITLE
Update the installation docs to clarify where the sources are

### DIFF
--- a/docs/pages/devdocs/install.dox
+++ b/docs/pages/devdocs/install.dox
@@ -6,7 +6,12 @@
  * \section dev_requirements_sec Requirements
  *
  * Please ensure that the required libraries described in the
- * \ref user_requirements_sec "User Requirements" section are installed.
+ * \ref user_requirements_sec "User Requirements" section are installed and
+ * clone the latest AqNWB source via:
+ *
+ * \code{.sh}
+ * git clone https://github.com/NeurodataWithoutBorders/aqnwb.git
+ * \endcode
  *
  * For developers we also recommend to install the following optional command line tools used for
  * generating the documentation, for code quality checks, and for debugging.
@@ -102,7 +107,7 @@
  * cmake --build --preset=dev --target=<name of the target>
  * \endcode
  *
- * \subsubsection  devbuild_target_options_subsubsec Target options
+ * \subsection  devbuild_target_options_subsubsec Target options
  * - `format-check`: run the `clang-format` tool on the codebase to check for formatting errors
  * - `format-fix` :  run the `clang-format` tool on the codebase with `FIX=YES` to both check and automatically fix for formatting errors
  * - `spell-check`: run the `codespell` tool on the codebase to check for common spelling errors

--- a/docs/pages/userdocs/install.dox
+++ b/docs/pages/userdocs/install.dox
@@ -10,6 +10,16 @@
  *  - [HDF5 >= 1.10](https://github.com/HDFGroup/hdf5)
  *  - [Boost](https://www.boost.org/)
  *
+ * \section userbuild_source_sec Source
+ *
+ * The source code for AqNWB is available online via the
+ * [AqNWB GitHub](https://github.com/NeurodataWithoutBorders/aqnwb) repository.
+ * To checkout the latest developer version, clone the repository via:
+ *
+ * \code{.sh}
+ * git clone https://github.com/NeurodataWithoutBorders/aqnwb.git
+ * \endcode
+ *
  * \section userbuild_build_sec Build
  *
  * Here are the steps for building in release mode with a multi-configuration generator:

--- a/src/nwb/hdmf/table/DynamicTable.hpp
+++ b/src/nwb/hdmf/table/DynamicTable.hpp
@@ -24,6 +24,7 @@ public:
    * @param path The location of the table in the file.
    * @param io A shared pointer to the IO object.
    * @param description The description of the table (optional).
+   * @param colNames Names of the columns in the table
    */
   DynamicTable(const std::string& path,
                std::shared_ptr<BaseIO> io,


### PR DESCRIPTION
A user visiting https://neurodatawithoutborders.github.io/aqnwb/ first may not know where the sources for AqNWB are located. This PR adds instructions for how to retrieve the AqNWB source code to the installation docs. In addition this PR fixes a docs build error due to a bad subsubsection heading and a missing parameter docstring in DynamicTable.