### PR TITLE
Add HDF5IO tests for add_read PR

### DIFF
--- a/src/io/hdf5/HDF5IO.hpp
+++ b/src/io/hdf5/HDF5IO.hpp
@@ -311,7 +311,7 @@ public:
   /**
    * @brief Returns the HDF5 type of object at a given path.
    * @param path The location in the file of the object.
-   * @return The type of object at the given path.
+   * @return The type of object at the given path. A negative value indicates that an error occurred.
    */
   H5O_type_t getH5ObjectType(const std::string& path) const;
 

--- a/tests/testHDF5IO.cpp
+++ b/tests/testHDF5IO.cpp
@@ -509,3 +509,33 @@ TEST_CASE("readDataset", "[hdf5io]")
     hdf5io->close();
   }
 }
+
+TEST_CASE("getH5ObjectType", "[hdf5io]")
+{
+  // create and open file
+  std::string filename = getTestFilePath("test_getH5ObjectType.h5");
+  IO::HDF5::HDF5IO hdf5io(filename);
+  hdf5io.open();
+
+  SECTION("group")
+  {
+    hdf5io.createGroup("/group");
+    REQUIRE(hdf5io.getH5ObjectType("/group") == H5O_TYPE_GROUP);
+  }
+
+  SECTION("dataset")
+  {
+    std::vector<int> testData = {1, 2, 3, 4, 5};
+    std::string dataPath = "/dataset";
+    hdf5io.createArrayDataSet(BaseDataType::I32, SizeArray {0}, SizeArray {1}, dataPath);
+    REQUIRE(hdf5io.getH5ObjectType(dataPath) == H5O_TYPE_DATASET);
+  }
+
+  SECTION("non_existent_object")
+  {
+    REQUIRE(hdf5io.getH5ObjectType("/non_existent") < 0); 
+  }
+
+  // close file
+  hdf5io.close();
+}


### PR DESCRIPTION
Add unit tests for public ``HDF5IO``-specifc functions (i.e., not inherited from ``BaseIO``. These may be moved to a separate PR:
    - [X] ``HDF5IO::getH5ObjectType``
    - [ ] ``HDF5IO::getNativeType``
    - [ ] ``HDF5IO::getH5Type`` 