### PR TITLE
Add coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,9 +17,15 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v4
 
-            - name: Install LCov
-              run: sudo apt-get update -q
-                && sudo apt-get install lcov -q -y
+            - name: Install LCov and dependencies
+              run: |
+                sudo apt-get update -q
+                sudo apt-get install -q -y lcov libhdf5-dev libboost-all-dev
+                git clone https://github.com/catchorg/Catch2.git
+                cd Catch2
+                git checkout "v3.5.3"
+                cmake -Bbuild -H. -DBUILD_TESTING=OFF
+                sudo cmake --build build/ --target install
 
             - name: Configure
               run: cmake --preset=ci-coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,42 @@
+name: Coverage
+
+on:
+    push:
+      branches:
+      - main
+
+    pull_request:
+      branches:
+      - main
+    workflow_dispatch:
+
+jobs:
+    coverage:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Install LCov
+              run: sudo apt-get update -q
+                && sudo apt-get install lcov -q -y
+
+            - name: Configure
+              run: cmake --preset=ci-coverage
+
+            - name: Build
+              run: cmake --build build/coverage -j 2
+
+            - name: Test
+              working-directory: build/coverage
+              run: ctest --output-on-failure --no-tests=error -j 2
+
+            - name: Process coverage info
+              run: cmake --build build/coverage -t coverage
+
+            - name: Upload coverage to Codecov
+              uses: codecov/codecov-action@v4
+              with:
+                file: build/coverage/coverage.info
+                fail_ci_if_error: true
+                token: ${{ secrets.CODECOV_TOKEN }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -121,6 +121,19 @@
       }
     },
     {
+      "name": "coverage-darwin",
+      "binaryDir": "${sourceDir}/build/coverage",
+      "inherits": "ci-darwin",
+      "hidden": true,
+      "cacheVariables": {
+        "ENABLE_COVERAGE": "ON",
+        "CMAKE_BUILD_TYPE": "Coverage",
+        "CMAKE_CXX_FLAGS_COVERAGE": "-Og -g --coverage",
+        "CMAKE_EXE_LINKER_FLAGS_COVERAGE": "--coverage",
+        "CMAKE_SHARED_LINKER_FLAGS_COVERAGE": "--coverage"
+      }
+    },
+    {
       "name": "ci-coverage",
       "inherits": ["coverage-linux", "dev-mode"],
       "cacheVariables": {

--- a/cmake/coverage.cmake
+++ b/cmake/coverage.cmake
@@ -7,9 +7,7 @@ set(
     lcov -c -q
     -o "${PROJECT_BINARY_DIR}/coverage.info"
     -d "${PROJECT_BINARY_DIR}"
-    # --ignore-errors inconsistent
-    # --filter range  # TODO - currently need these flags to get working locally
-    --include "${PROJECT_SOURCE_DIR}/*"
+    --include "${PROJECT_SOURCE_DIR}/src/*"
     CACHE STRING
     "; separated command to generate a trace for the 'coverage' target"
 )
@@ -17,9 +15,6 @@ set(
 set(
     COVERAGE_HTML_COMMAND
     genhtml --legend -q
-    # --ignore-errors inconsistent
-    # --ignore-errors range
-    # --ignore-errors category
     "${PROJECT_BINARY_DIR}/coverage.info"
     -p "${PROJECT_SOURCE_DIR}"
     -o "${PROJECT_BINARY_DIR}/coverage_html"

--- a/cmake/coverage.cmake
+++ b/cmake/coverage.cmake
@@ -7,6 +7,8 @@ set(
     lcov -c -q
     -o "${PROJECT_BINARY_DIR}/coverage.info"
     -d "${PROJECT_BINARY_DIR}"
+    # --ignore-errors inconsistent
+    # --filter range  # TODO - currently need these flags to get working locally
     --include "${PROJECT_SOURCE_DIR}/*"
     CACHE STRING
     "; separated command to generate a trace for the 'coverage' target"
@@ -14,7 +16,10 @@ set(
 
 set(
     COVERAGE_HTML_COMMAND
-    genhtml --legend -f -q
+    genhtml --legend -q
+    # --ignore-errors inconsistent
+    # --ignore-errors range
+    # --ignore-errors category
     "${PROJECT_BINARY_DIR}/coverage.info"
     -p "${PROJECT_SOURCE_DIR}"
     -o "${PROJECT_BINARY_DIR}/coverage_html"


### PR DESCRIPTION
Fix https://github.com/NeurodataWithoutBorders/aqnwb/issues/70. 

Generates a code coverage report and uploads to codecov.io using the cmake coverage preset.