### PR TITLE
address validation errors in add_read

### DIFF
--- a/src/io/hdf5/HDF5IO.cpp
+++ b/src/io/hdf5/HDF5IO.cpp
@@ -898,17 +898,14 @@ Status HDF5IO::createStringDataSet(const std::string& path,
   if (!m_opened)
     return Status::Failure;
 
-  std::vector<const char*> cStrs;
-  cStrs.reserve(values.size());
-  for (const auto& str : values) {
-    cStrs.push_back(str.c_str());
-  }
-
   std::unique_ptr<IO::BaseRecordingData> dataset;
   dataset = std::unique_ptr<IO::BaseRecordingData>(createArrayDataSet(
       IO::BaseDataType::V_STR, SizeArray {values.size()}, SizeArray {1}, path));
-  dataset->writeDataBlock(
-      std::vector<SizeType>(1, 1), IO::BaseDataType::V_STR, cStrs.data());
+
+  dataset->writeStringDataBlock(std::vector<SizeType> {1},
+                                std::vector<SizeType> {0},
+                                IO::BaseDataType::V_STR,
+                                values);
 
   return Status::Success;
 }

--- a/src/nwb/file/ElectrodeTable.cpp
+++ b/src/nwb/file/ElectrodeTable.cpp
@@ -25,9 +25,7 @@ ElectrodeTable::ElectrodeTable(std::shared_ptr<IO::BaseIO> io)
 
 ElectrodeTable::ElectrodeTable(const std::string& path,
                                std::shared_ptr<IO::BaseIO> io)
-    : DynamicTable(
-        electrodeTablePath,  // use the electrodeTablePath
-        io)  // TODO May need to initialize the colNames in DynamicTable
+    : DynamicTable(electrodeTablePath, io)
     , m_electrodeDataset(std::make_unique<ElementIdentifiers>(
           AQNWB::mergePaths(electrodeTablePath, "id"), io))
     , m_groupNamesDataset(std::make_unique<VectorData>(

--- a/src/nwb/file/ElectrodeTable.cpp
+++ b/src/nwb/file/ElectrodeTable.cpp
@@ -26,8 +26,8 @@ ElectrodeTable::ElectrodeTable(std::shared_ptr<IO::BaseIO> io)
 ElectrodeTable::ElectrodeTable(const std::string& path,
                                std::shared_ptr<IO::BaseIO> io)
     : DynamicTable(
-          electrodeTablePath,  // use the electrodeTablePath
-          io)  // TODO May need to initialize the colNames in DynamicTable
+        electrodeTablePath,  // use the electrodeTablePath
+        io)  // TODO May need to initialize the colNames in DynamicTable
     , m_electrodeDataset(std::make_unique<ElementIdentifiers>(
           AQNWB::mergePaths(electrodeTablePath, "id"), io))
     , m_groupNamesDataset(std::make_unique<VectorData>(

--- a/src/nwb/hdmf/table/DynamicTable.cpp
+++ b/src/nwb/hdmf/table/DynamicTable.cpp
@@ -40,10 +40,11 @@ void DynamicTable::addColumn(const std::string& name,
   } else {
     // write in loop because variable length string
     for (SizeType i = 0; i < values.size(); i++)
-      vectorData->m_dataset->writeDataBlock(
-          std::vector<SizeType>(1, 1),
+      vectorData->m_dataset->writeStringDataBlock(
+          std::vector<SizeType> {1},
+          std::vector<SizeType> {i},
           IO::BaseDataType::STR(values[i].size() + 1),
-          values[i].c_str());  // TODO - add tests for this
+          values);  // TODO - add tests for this
     m_io->createCommonNWBAttributes(AQNWB::mergePaths(m_path, name),
                                     vectorData->getNamespace(),
                                     vectorData->getTypeName(),

--- a/tests/examples/test_example.cpp
+++ b/tests/examples/test_example.cpp
@@ -8,7 +8,7 @@ TEST_CASE("SimpleExamples", "[hdf5io]")
 {
   SECTION("docsExample")
   {
-    std::string path = getTestFilePath("testWithSWMRMode.h5");
+    std::string path = getTestFilePath("testSimpleExample.h5");
     // [example_hdf5io_code_snippet]
     std::unique_ptr<AQNWB::IO::HDF5::HDF5IO> hdf5io =
         std::make_unique<AQNWB::IO::HDF5::HDF5IO>(path);

--- a/tests/testNWBFile.cpp
+++ b/tests/testNWBFile.cpp
@@ -102,7 +102,7 @@ TEST_CASE("createMultipleEcephysDatasets", "[nwb]")
   nwbfile.initialize(generateUuid());
 
   // create Electrical Series
-  std::vector<Types::ChannelVector> mockArrays = getMockChannelArrays(1, 2);
+  std::vector<Types::ChannelVector> mockArrays = getMockChannelArrays(2, 2);
   std::vector<std::string> mockChannelNames =
       getMockChannelArrayNames("esdata");
   std::unique_ptr<NWB::RecordingContainers> recordingContainers =
@@ -130,8 +130,10 @@ TEST_CASE("createMultipleEcephysDatasets", "[nwb]")
   REQUIRE(resultStart == Status::Success);
 
   // write electrical series data
-  std::vector<float> mockData = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
-  std::vector<double> mockTimestamps = {0.1, 0.3, 0.4, 0.5, 0.8};
+  std::vector<float> mockData = {
+      1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+  std::vector<double> mockTimestamps = {
+      0.1, 0.3, 0.4, 0.5, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3};
   std::vector<SizeType> positionOffset = {0, 0};
   std::vector<SizeType> dataShape = {mockData.size(), 0};
 
@@ -151,8 +153,10 @@ TEST_CASE("createMultipleEcephysDatasets", "[nwb]")
   NWB::SpikeEventSeries* ses1 =
       static_cast<NWB::SpikeEventSeries*>(recordingContainers->getContainer(3));
   for (SizeType i = 0; i < numEvents; ++i) {
-    ses0->writeSpike(numSamples, 1, mockData.data(), &mockTimestamps[0]);
-    ses1->writeSpike(numSamples, 1, mockData.data(), &mockTimestamps[0]);
+    ses0->writeSpike(
+        numSamples, mockArrays.size(), mockData.data(), &mockTimestamps[i]);
+    ses1->writeSpike(
+        numSamples, mockArrays.size(), mockData.data(), &mockTimestamps[i]);
   }
 
   nwbfile.finalize();


### PR DESCRIPTION
I looked more closely at the nwbinspector errors and most were due to the updates to the string dataset write.

I believe the remaining critical error is actually an issue on the nwbinspector end. According to the [schema](https://github.com/NeurodataWithoutBorders/nwb-schema/blob/d5a931d2cc0ae059d917705b7583136d756a2c8b/core/nwb.ecephys.yaml#L68-L84), SpikeEventSeries can have dimensions [nevents, nsamples] when it contains data from a single channel, but the inspector will throw an error that the second dimension does not match the number of electrodes: 

```
0  CRITICAL
===========

0.0  createESandSES.nwb: check_electrical_series_dims - 'SpikeEventSeries' object at location '/acquisition/spikedata1'
       Message: The second dimension of data does not match the length of electrodes. Your data may be transposed.
```

I can fix the issue here by changing the test to use multiple channels, but will also open a related issue on the nwbinspector side 