### PR TITLE
Make calling io->open() explicit

### DIFF
--- a/src/nwb/NWBFile.hpp
+++ b/src/nwb/NWBFile.hpp
@@ -72,6 +72,15 @@ public:
                     const std::string& dataCollection = "");
 
   /**
+   * @brief Check if the NWB file is initialized.
+   *
+   * The function simply checks if the top-level group structure exists.
+   *
+   * @return bool True if the file is initialized, false otherwise.
+   */
+  bool isInitialized() const;
+
+  /**
    * @brief Finalizes the NWB file by closing it.
    */
   Status finalize();

--- a/tests/examples/testWorkflowExamples.cpp
+++ b/tests/examples/testWorkflowExamples.cpp
@@ -36,6 +36,8 @@ TEST_CASE("workflowExamples")
     std::string path = getTestFilePath("exampleRecording.nwb");
     // [example_workflow_io_snippet]
     std::shared_ptr<BaseIO> io = createIO("HDF5", path);
+    io->open();
+    REQUIRE(io->isOpen());
     // [example_workflow_io_snippet]
 
     // [example_workflow_recording_containers_snippet]
@@ -45,20 +47,24 @@ TEST_CASE("workflowExamples")
 
     // [example_workflow_nwbfile_snippet]
     std::unique_ptr<NWB::NWBFile> nwbfile = std::make_unique<NWB::NWBFile>(io);
-    nwbfile->initialize(generateUuid());
+    Status initStatus = nwbfile->initialize(generateUuid());
+    REQUIRE(initStatus == Status::Success);
     // [example_workflow_nwbfile_snippet]
 
     // [example_workflow_datasets_snippet]
     std::vector<SizeType> containerIndexes;
-    nwbfile->createElectricalSeries(mockRecordingArrays,
-                                    mockChannelNames,
-                                    BaseDataType::I16,
-                                    recordingContainers.get(),
-                                    containerIndexes);
+    Status elecSeriesStatus =
+        nwbfile->createElectricalSeries(mockRecordingArrays,
+                                        mockChannelNames,
+                                        BaseDataType::I16,
+                                        recordingContainers.get(),
+                                        containerIndexes);
+    REQUIRE(elecSeriesStatus == Status::Success);
     // [example_workflow_datasets_snippet]
 
     // [example_workflow_start_snippet]
-    io->startRecording();
+    Status startRecordingStatus = io->startRecording();
+    REQUIRE(startRecordingStatus == Status::Success);
     // [example_workflow_start_snippet]
 
     // write data during the recording
@@ -110,6 +116,7 @@ TEST_CASE("workflowExamples")
     // [example_workflow_stop_snippet]
     io->stopRecording();
     nwbfile->finalize();
+    io->close();
     // [example_workflow_stop_snippet]
   }
 }

--- a/tests/examples/test_ecephys_data_read.cpp
+++ b/tests/examples/test_ecephys_data_read.cpp
@@ -51,10 +51,12 @@ TEST_CASE("ElectricalSeriesReadExample", "[ecephys]")
     // setup io object
     std::string path = getTestFilePath("ElectricalSeriesReadExample.h5");
     std::shared_ptr<BaseIO> io = createIO("HDF5", path);
+    io->open();
 
     // setup the NWBFile
     NWB::NWBFile nwbfile(io);
-    nwbfile.initialize(generateUuid());
+    Status initStatus = nwbfile.initialize(generateUuid());
+    REQUIRE(initStatus == Status::Success);
 
     // create the RecordingContainer for managing recordings
     std::unique_ptr<NWB::RecordingContainers> recordingContainers =

--- a/tests/testNWBFile.cpp
+++ b/tests/testNWBFile.cpp
@@ -32,6 +32,7 @@ TEST_CASE("createElectricalSeries", "[nwb]")
   // initialize nwbfile object and create base structure
   std::shared_ptr<IO::HDF5::HDF5IO> io =
       std::make_shared<IO::HDF5::HDF5IO>(filename);
+  io->open();
   NWB::NWBFile nwbfile(io);
   nwbfile.initialize(generateUuid());
 
@@ -98,6 +99,7 @@ TEST_CASE("createMultipleEcephysDatasets", "[nwb]")
 
   // initialize nwbfile object and create base structure
   std::shared_ptr<HDF5::HDF5IO> io = std::make_shared<HDF5::HDF5IO>(filename);
+  io->open();
   NWB::NWBFile nwbfile(io);
   nwbfile.initialize(generateUuid());
 
@@ -169,15 +171,19 @@ TEST_CASE("setCanModifyObjectsMode", "[nwb]")
   // initialize nwbfile object and create base structure with HDF5IO object
   std::shared_ptr<IO::HDF5::HDF5IO> io =
       std::make_shared<IO::HDF5::HDF5IO>(filename);
+  io->open();
   NWB::NWBFile nwbfile(io);
-  nwbfile.initialize(generateUuid());
+  Status initStatus = nwbfile.initialize(generateUuid());
+  REQUIRE(initStatus == Status::Success);
 
   // start recording
   Status resultStart = io->startRecording();
   REQUIRE(resultStart == Status::Success);
 
   // test that modifying the file structure after starting the recording fails
-  Status resultInitializePostStart = nwbfile.initialize(generateUuid());
+  // Status resultInitializePostStart = nwbfile.initialize(generateUuid());
+  Status resultInitializePostStart = io->createGroup("/new_group");
+  REQUIRE(io->canModifyObjects() == false);
   REQUIRE(resultInitializePostStart == Status::Failure);
 
   // test that dataset creation fails after starting the recording

--- a/tests/testRecordingWorkflow.cpp
+++ b/tests/testRecordingWorkflow.cpp
@@ -38,6 +38,7 @@ TEST_CASE("writeContinuousData", "[recording]")
     // 1. create IO object
     std::string path = getTestFilePath("testContinuousRecording1.nwb");
     std::shared_ptr<BaseIO> io = createIO("HDF5", path);
+    io->open();
 
     // 2. create RecordingContainers object
     std::unique_ptr<NWB::RecordingContainers> recordingContainers =


### PR DESCRIPTION
While working on debugging #123 I came across the issue that `open` seemed to be called more than once on the same file. Part of the issue seems to be that `io->open` is being called implicitly on behalf of the user in `NWBFile.initialize`. This PR updates the logic to always require that the user call `io-open` before making any modifications to the file, e.g, initializing the `NWBFile`. This PR makes a few changes:

- [X] Modified `NWBFile.initialize` to more robustly check if a file has been initialized. The current logic requires that a file must not exist on disk before calling `NWBFile.initialize`, i.e., if a user calls `io->open()` before calling `NWBFile.initialize`, the current logic would fail.
- [X] Added `NWBFile.isInitialized` to check whether the expected file structure exists within the file
- [X] Updated `HDF5IO.create*` methods to perform the more strict check that `canModifyObjects()` is true rather than just whether the file `isOpen()`
- [X] Updated test suite to call `io->open()` directly where it was missing
- [X] Updated `testWorkflowExamples.cpp` to add `REQUIRE` checks . The example previously passed independent of whether the workflow was successful or not because the status of I/O operations was not being checked. Since the AqNWB functions did not raise exceptions (but simply returned a ``Status::Failure``) the workflow would run to completion even if the file was not being created at all. 