### PR TITLE
Support reading of arbitrary fields 

### DIFF
--- a/docs/pages/userdocs/read.dox
+++ b/docs/pages/userdocs/read.dox
@@ -308,7 +308,7 @@
  * - \ref AQNWB::IO::BaseIO "BaseIO", \ref AQNWB::IO::HDF5::HDF5IO "HDF5IO" are responsible for
  *   i) reading type attribute and group information, ii) searching the file for typed objects via
  *   \ref AQNWB::IO::BaseIO::findTypes "findTypes()" methods, and iii) retrieving the paths of all
- *   object within a group via  \ref AQNWB::IO::BaseIO::getGroupObjects "getGroupObjects()"
+ *   object associated with a storage objects (e.g., a Group) via  \ref AQNWB::IO::BaseIO::getStorageObjects "getStoragebjects()"
  *
  * \subsubsection read_design_wrapper_registeredType RegisteredType
  *
@@ -320,7 +320,9 @@
  * methods that we can use to instantiate any registered subclass just using the ``io`` object
  * and ``path`` for the object in the file. \ref AQNWB::NWB::RegisteredType "RegisteredType" can read
  * the type information from the corresponding `namespace` and `neurodata_type` attributes to
- * determine the full type and in run look up the corresponding class in its registry and create the type.
+ * determine the full type,  then look up the corresponding class in its registry, and then create the type.
+ * Using \ref AQNWB::NWB::RegisteredType::readField "RegisteredType::readField" also provides a 
+ * general mechanism for reading arbitrary fields.
  *
  * \subsubsection read_design_wrapper_subtypes Child classes of RegisteredType (e.g., Container)
  *
@@ -540,5 +542,26 @@
  *
  *  \snippet tests/examples/test_ecephys_data_read.cpp  example_read_only_stringattr_snippet
  *
+ *
+ * \subsubsection read_design_example_read_arbitrary_field Reading arbitrary fields
+ *
+ * Even if there is no dedicated `DEFINE_FIELD` definition available, we can still read 
+ * any arbitrary sub-field associated with a particular \ref AQNWB::NWB::RegisteredType "RegisteredType"
+ * via the generic \ref AQNWB::NWB::RegisteredType::readField "RegisteredType::readField" method. The main 
+ * difference is that for datasets and attributes we need to specify all the additional information 
+ * (e.g., the relative path, object type, and data type) ourselves, whereas using `DEFINE_FIELD` 
+ * this information has already been specified for us. For example, to read the data from 
+ * the \ref AQNWB::NWB::ElectricalSeries "ElectricalSeries" we can call:
+ *
+ * \snippet tests/examples/test_ecephys_data_read.cpp example_read_generic_dataset_field_snippet
+ *
+ * Similarly, we can also read any sub-fields that are itself \ref AQNWB::NWB::RegisteredType "RegisteredType"
+ * objects via \ref AQNWB::NWB::RegisteredType::readField "RegisteredType::readField" (e.g., to read custom
+ * \ref AQNWB::NWB::VectorData "VectorData" columns of a \ref AQNWB::NWB::DynamicTable "DynamicTable"). In 
+ * contrast to dataset and attribute fields, we here only need to specify the relative path of the field.
+ *  \ref AQNWB::NWB::RegisteredType "RegisteredType" in turn can read the type information from the 
+ * `neurodata_type` and `namespace` attributes in the file directly. 
+ *
+ * \snippet tests/examples/test_ecephys_data_read.cpp example_read_generic_registeredtype_field_snippet
  */
 

--- a/docs/pages/userdocs/read.dox
+++ b/docs/pages/userdocs/read.dox
@@ -308,7 +308,7 @@
  * - \ref AQNWB::IO::BaseIO "BaseIO", \ref AQNWB::IO::HDF5::HDF5IO "HDF5IO" are responsible for
  *   i) reading type attribute and group information, ii) searching the file for typed objects via
  *   \ref AQNWB::IO::BaseIO::findTypes "findTypes()" methods, and iii) retrieving the paths of all
- *   object associated with a storage objects (e.g., a Group) via  \ref AQNWB::IO::BaseIO::getStorageObjects "getStoragebjects()"
+ *   object associated with a storage object (e.g., a Group) via  \ref AQNWB::IO::BaseIO::getStorageObjects "getStorageObjects()"
  *
  * \subsubsection read_design_wrapper_registeredType RegisteredType
  *

--- a/src/Types.hpp
+++ b/src/Types.hpp
@@ -36,6 +36,19 @@ public:
   };
 
   /**
+   *  \brief Helper struct to check if a value is a data field, i.e.,
+   * Dataset or Attribute
+   *
+   * This function is used to enforce constrains on templated functions that
+   * should only be callable for valid StorageObjectType values
+   */
+  template<StorageObjectType T>
+  struct IsDataStorageObjectType
+      : std::integral_constant<bool, (T == Dataset || T == Attribute)>
+  {
+  };
+
+  /**
    * @brief Alias for the size type used in the project.
    */
   using SizeType = size_t;

--- a/src/Types.hpp
+++ b/src/Types.hpp
@@ -39,7 +39,7 @@ public:
    *  \brief Helper struct to check if a value is a data field, i.e.,
    * Dataset or Attribute
    *
-   * This function is used to enforce constrains on templated functions that
+   * This function is used to enforce constraints on templated functions that
    * should only be callable for valid StorageObjectType values
    */
   template<StorageObjectType T>

--- a/src/io/BaseIO.cpp
+++ b/src/io/BaseIO.cpp
@@ -77,7 +77,6 @@ std::unordered_map<std::string, std::string> BaseIO::findTypes(
   {
     // Check if the current object exists as a dataset or group
     if (objectExists(current_path)) {
-      std::cout << "Current Path: " << current_path << std::endl;
       // Check if we have a typed object
       if (attributeExists(current_path + "/neurodata_type")
           && attributeExists(current_path + "/namespace"))
@@ -92,8 +91,6 @@ std::unordered_map<std::string, std::string> BaseIO::findTypes(
           std::string full_type =
               namespace_attr.data[0] + "::" + neurodata_type_attr.data[0];
 
-          std::cout << "Full name: " << full_type << std::endl;
-
           // Check if the full type matches any of the given types
           if (types.find(full_type) != types.end()) {
             found_types[current_path] = full_type;
@@ -103,9 +100,14 @@ std::unordered_map<std::string, std::string> BaseIO::findTypes(
           // object
           if (search_mode == SearchMode::CONTINUE_ON_TYPE) {
             // Get the list of objects inside the current group
-            std::vector<std::string> objects = getGroupObjects(current_path);
+            std::vector<std::pair<std::string, StorageObjectType>> objects =
+                getStorageObjects(current_path, StorageObjectType::Undefined);
             for (const auto& obj : objects) {
-              searchTypes(AQNWB::mergePaths(current_path, obj));
+              if (obj.second == StorageObjectType::Group
+                  || obj.second == StorageObjectType::Dataset)
+              {
+                searchTypes(AQNWB::mergePaths(current_path, obj.first));
+              }
             }
           }
         } catch (...) {
@@ -117,9 +119,14 @@ std::unordered_map<std::string, std::string> BaseIO::findTypes(
       else
       {
         // Get the list of objects inside the current group
-        std::vector<std::string> objects = getGroupObjects(current_path);
+        std::vector<std::pair<std::string, StorageObjectType>> objects =
+            getStorageObjects(current_path, StorageObjectType::Undefined);
         for (const auto& obj : objects) {
-          searchTypes(AQNWB::mergePaths(current_path, obj));
+          if (obj.second == StorageObjectType::Group
+              || obj.second == StorageObjectType::Dataset)
+          {
+            searchTypes(AQNWB::mergePaths(current_path, obj.first));
+          }
         }
       }
     }

--- a/src/io/BaseIO.hpp
+++ b/src/io/BaseIO.hpp
@@ -223,19 +223,26 @@ public:
   virtual bool attributeExists(const std::string& path) const = 0;
 
   /**
-   * @brief Gets the list of objects inside a group.
+   * @brief Gets the list of storage objects (groups, datasets, attributes)
+   * inside a group.
    *
-   * This function returns a vector of relative paths of all objects inside
-   * the specified group. If the input path is not a group (e.g., as dataset
-   * or attribute or invalid object), then an empty list should be
-   * returned.
+   * This function returns the relative paths and storage type of all objects
+   * inside the specified group. If the input path is an attribute then an empty
+   * list should be returned. If the input path is a dataset, then only the
+   * attributes will be returned. Note, this function is not recursive, i.e.,
+   * it only looks for storage objects associated directly with the given path.
    *
    * @param path The path to the group.
+   * @param objectType Define which types of storage object to look for, i.e.,
+   * only objects of this specified type will be returned.
    *
-   * @return A vector of relative paths of all objects inside the group.
+   * @return A vector of pairs of relative paths and their corresponding storage
+   * object types.
    */
-  virtual std::vector<std::string> getGroupObjects(
-      const std::string& path) const = 0;
+  virtual std::vector<std::pair<std::string, StorageObjectType>>
+  getStorageObjects(const std::string& path,
+                    const StorageObjectType& objectType =
+                        StorageObjectType::Undefined) const = 0;
 
   /**
    * @brief Finds all datasets and groups of the given types in the HDF5 file.

--- a/src/io/BaseIO.hpp
+++ b/src/io/BaseIO.hpp
@@ -96,12 +96,12 @@ enum class SearchMode
   /**
    * @brief Stop searching inside an object once a matching type is found.
    */
-  STOP_ON_TYPE,
+  STOP_ON_TYPE = 1,
   /**
    * @brief Continue searching inside an object even after a matching type is
    * found.
    */
-  CONTINUE_ON_TYPE
+  CONTINUE_ON_TYPE = 2,
 };
 
 /**

--- a/src/io/hdf5/HDF5IO.hpp
+++ b/src/io/hdf5/HDF5IO.hpp
@@ -294,19 +294,26 @@ public:
   bool attributeExists(const std::string& path) const override;
 
   /**
-   * @brief Gets the list of objects inside a group.
+   * @brief Gets the list of storage objects (groups, datasets, attributes)
+   * inside a group.
    *
-   * This function returns a vector of relative paths of all objects inside
-   * the specified group. If the input path is not a group (e.g., as dataset
-   * or attribute or invalid object), then an empty list should be
-   * returned.
+   * This function returns the relative paths and storage type of all objects
+   * inside the specified group. If the input path is an attribute then an empty
+   * list should be returned. If the input path is a dataset, then only the
+   * attributes will be returned. Note, this function is not recursive, i.e.,
+   * it only looks for storage objects associated directly with the given path.
    *
    * @param path The path to the group.
+   * @param objectType Define which types of storage object to look for, i.e.,
+   * only objects of this specified type will be returned.
    *
-   * @return A vector of relative paths of all objects inside the group.
+   * @return A vector of pairs of relative paths and their corresponding storage
+   * object types.
    */
-  std::vector<std::string> getGroupObjects(
-      const std::string& path) const override;
+  virtual std::vector<std::pair<std::string, StorageObjectType>>
+  getStorageObjects(const std::string& path,
+                    const StorageObjectType& objectType =
+                        StorageObjectType::Undefined) const override;
 
   /**
    * @brief Returns the HDF5 type of object at a given path.

--- a/src/nwb/NWBFile.cpp
+++ b/src/nwb/NWBFile.cpp
@@ -65,7 +65,8 @@ Status NWBFile::initialize(const std::string& identifierText,
 
 bool NWBFile::isInitialized() const
 {
-  auto existingGroupObjects = m_io->getGroupObjects("/");
+  std::vector<std::pair<std::string, StorageObjectType>> existingGroupObjects =
+      m_io->getStorageObjects("/", StorageObjectType::Group);
   if (existingGroupObjects.size() == 0) {
     return false;
   }
@@ -84,8 +85,8 @@ bool NWBFile::isInitialized() const
   // Iterate over the existing objects and add to foundObjects if it's a
   // required object
   for (const auto& obj : existingGroupObjects) {
-    if (requiredObjects.find(obj) != requiredObjects.end()) {
-      foundObjects.insert(obj);
+    if (requiredObjects.find(obj.first) != requiredObjects.end()) {
+      foundObjects.insert(obj.first);
     }
   }
 

--- a/src/nwb/RegisteredType.hpp
+++ b/src/nwb/RegisteredType.hpp
@@ -206,7 +206,7 @@ public:
    * DEFINE_FIELD specified for the field. If a DEFINE_FIELD exists then
    * the corresponding read method should be used as it avoids the need
    * for specifying most (if not all) of the function an template
-   * parameteres needed by this function.
+   * parameters needed by this function.
    *
    * @param fieldPath The relative path of the field within the current type,
    * i.e., relative to `m_path`

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ include(Catch)
 # ---- Tests ----
 
 add_executable(aqnwb_test
+    testBaseIO.cpp
     testData.cpp
     testDevice.cpp
     testEcephys.cpp

--- a/tests/examples/test_ecephys_data_read.cpp
+++ b/tests/examples/test_ecephys_data_read.cpp
@@ -268,5 +268,29 @@ TEST_CASE("ElectricalSeriesReadExample", "[ecephys]")
         readElectricalSeries->readDataUnit()->values().data[0];
     REQUIRE(esUnitValue == std::string("volts"));
     // [example_read_only_stringattr_snippet]
+
+    // [example_read_generic_dataset_field_snippet]
+    // Read the data field via the generic readField method
+    auto readElectricalSeriesData3 =
+        readElectricalSeries->readField<StorageObjectType::Dataset, float>(
+            std::string("data"));
+    // Read the data values as usual
+    DataBlock<float> readDataValues3 = readElectricalSeriesData3->values();
+    REQUIRE(readDataValues3.data.size() == (numSamples * numChannels));
+    // [example_read_generic_dataset_field_snippet]
+
+    // [example_read_generic_registeredtype_field_snippet]
+    // read the NWBFile
+    auto readNWBFile =
+        NWB::RegisteredType::create<AQNWB::NWB::NWBFile>("/", readio);
+    // read the ElectricalSeries from the NWBFile object via the readField
+    // method returning a generic std::shared_ptr<RegisteredType>
+    auto readRegisteredType = readNWBFile->readField(esdata_path);
+    // cast the generic pointer to the more specific ElectricalSeries
+    std::shared_ptr<AQNWB::NWB::ElectricalSeries> readElectricalSeries2 =
+        std::dynamic_pointer_cast<AQNWB::NWB::ElectricalSeries>(
+            readRegisteredType);
+    REQUIRE(readElectricalSeries2 != nullptr);
+    // [example_read_generic_registeredtype_field_snippet]
   }
 }

--- a/tests/testBaseIO.cpp
+++ b/tests/testBaseIO.cpp
@@ -31,6 +31,21 @@ TEST_CASE("Test findTypes functionality", "[BaseIO]")
     REQUIRE(result["/"] == "core::NWBFile");
   }
 
+  SECTION("Search for dataset type")
+  {
+    // Create root group with type attributes
+    io.createGroup("/");
+    io.createArrayDataSet(
+        BaseDataType::I32, SizeArray {0}, SizeArray {1}, "/dataset1");
+    io.createAttribute("hdmf-common", "/dataset1", "namespace");
+    io.createAttribute("VectorData", "/dataset1", "neurodata_type");
+
+    auto result = io.findTypes(
+        "/", {"hdmf-common::VectorData"}, SearchMode::STOP_ON_TYPE);
+    REQUIRE(result.size() == 1);
+    REQUIRE(result["/dataset1"] == "hdmf-common::VectorData");
+  }
+
   SECTION("Multiple nested types with STOP_ON_TYPE")
   {
     // Setup hierarchy

--- a/tests/testBaseIO.cpp
+++ b/tests/testBaseIO.cpp
@@ -1,0 +1,107 @@
+#include <catch2/catch_all.hpp>
+
+#include "io/hdf5/HDF5IO.hpp"
+#include "testUtils.hpp"
+
+using namespace AQNWB::IO;
+
+TEST_CASE("Test findTypes functionality", "[BaseIO]")
+{
+  std::string filename = getTestFilePath("test_findTypes.h5");
+  HDF5::HDF5IO io(filename);
+  io.open(FileMode::Overwrite);
+
+  SECTION("Empty file returns empty result")
+  {
+    auto result =
+        io.findTypes("/", {"core::NWBFile"}, SearchMode::STOP_ON_TYPE);
+    REQUIRE(result.empty());
+  }
+
+  SECTION("Single type at root")
+  {
+    // Create root group with type attributes
+    io.createGroup("/");
+    io.createAttribute("core", "/", "namespace");
+    io.createAttribute("NWBFile", "/", "neurodata_type");
+
+    auto result =
+        io.findTypes("/", {"core::NWBFile"}, SearchMode::STOP_ON_TYPE);
+    REQUIRE(result.size() == 1);
+    REQUIRE(result["/"] == "core::NWBFile");
+  }
+
+  SECTION("Multiple nested types with STOP_ON_TYPE")
+  {
+    // Setup hierarchy
+    io.createGroup("/");
+    io.createAttribute("core", "/", "namespace");
+    io.createAttribute("NWBFile", "/", "neurodata_type");
+
+    io.createGroup("/testProcessingModule");
+    io.createAttribute("core", "/testProcessingModule", "namespace");
+    io.createAttribute(
+        "ProcessingModule", "/testProcessingModule", "neurodata_type");
+
+    auto result = io.findTypes("/",
+                               {"core::NWBFile", "core::ProcessingModule"},
+                               SearchMode::STOP_ON_TYPE);
+    REQUIRE(result.size() == 1);
+    REQUIRE(result["/"] == "core::NWBFile");
+  }
+
+  SECTION("Multiple nested types with CONTINUE_ON_TYPE")
+  {
+    // Setup hierarchy
+    io.createGroup("/");
+    io.createAttribute("core", "/", "namespace");
+    io.createAttribute("NWBFile", "/", "neurodata_type");
+
+    io.createGroup("/testProcessingModule");
+    io.createAttribute("core", "/testProcessingModule", "namespace");
+    io.createAttribute(
+        "ProcessingModule", "/testProcessingModule", "neurodata_type");
+
+    auto result = io.findTypes("/",
+                               {"core::NWBFile", "core::ProcessingModule"},
+                               SearchMode::CONTINUE_ON_TYPE);
+    REQUIRE(result.size() == 2);
+    REQUIRE(result["/"] == "core::NWBFile");
+    REQUIRE(result["/testProcessingModule"] == "core::ProcessingModule");
+  }
+
+  SECTION("Non-matching types are not included")
+  {
+    // Setup hierarchy
+    io.createGroup("/");
+    io.createAttribute("core", "/", "namespace");
+    io.createAttribute("NWBFile", "/", "neurodata_type");
+
+    io.createGroup("/testProcessingModule");
+    io.createAttribute("core", "/testProcessingModule", "namespace");
+    io.createAttribute(
+        "ProcessingModule", "/testProcessingModule", "neurodata_type");
+
+    auto result =
+        io.findTypes("/", {"core::Device"}, SearchMode::CONTINUE_ON_TYPE);
+    REQUIRE(result.empty());
+  }
+
+  SECTION("Missing attributes are handled gracefully")
+  {
+    // Create group with missing neurodata_type attribute
+    io.createGroup("/");
+    io.createAttribute("core", "/", "namespace");
+
+    io.createGroup("/testProcessingModule");
+    io.createAttribute("core", "/testProcessingModule", "namespace");
+    io.createAttribute(
+        "ProcessingModule", "/testProcessingModule", "neurodata_type");
+
+    auto result = io.findTypes(
+        "/", {"core::ProcessingModule"}, SearchMode::CONTINUE_ON_TYPE);
+    REQUIRE(result.size() == 1);
+    REQUIRE(result["/testProcessingModule"] == "core::ProcessingModule");
+  }
+  io.close();
+}

--- a/tests/testHDF5IO.cpp
+++ b/tests/testHDF5IO.cpp
@@ -142,6 +142,38 @@ TEST_CASE("getStorageObjects", "[hdf5io]")
     REQUIRE(groupContent.size() == 0);
   }
 
+  SECTION("attribute")
+  {
+    int attrData1 = 42;
+    hdf5io.createAttribute(BaseDataType::I32, &attrData1, "/", "attr1");
+    auto attributeContent = hdf5io.getStorageObjects("/attr1");
+    REQUIRE(attributeContent.size() == 0);
+  }
+
+  SECTION("dataset w/o attribute")
+  {
+    // Dataset without attributes
+    hdf5io.createArrayDataSet(
+        BaseDataType::I32, SizeArray {0}, SizeArray {1}, "/data");
+    auto datasetContent = hdf5io.getStorageObjects("/data");
+    REQUIRE(datasetContent.size() == 0);
+
+    // Dataset with attribute
+    int attrData1 = 42;
+    hdf5io.createAttribute(BaseDataType::I32, &attrData1, "/data", "attr1");
+    auto dataContent2 = hdf5io.getStorageObjects("/data");
+    REQUIRE(dataContent2.size() == 1);
+    REQUIRE(
+        dataContent2[0]
+        == std::make_pair(std::string("attr1"), StorageObjectType::Attribute));
+  }
+
+  SECTION("invalid path")
+  {
+    auto invalidPathContent = hdf5io.getStorageObjects("/invalid/path");
+    REQUIRE(invalidPathContent.size() == 0);
+  }
+
   SECTION("group with datasets, subgroups, and attributes")
   {
     hdf5io.createGroup("/data");

--- a/tests/testHDF5IO.cpp
+++ b/tests/testHDF5IO.cpp
@@ -1437,8 +1437,29 @@ TEST_CASE("HDF5IO; read dataset", "[hdf5io]")
 
   SECTION("read unsupported data type")
   {
-    // TODO Add a test that tries to read some unsupported data type
-    //      such as a strange compound data type
+    // open file
+    std::string path = getTestFilePath("test_ReadUnsupportedDataType.h5");
+    std::shared_ptr<IO::HDF5::HDF5IO> hdf5io =
+        std::make_shared<IO::HDF5::HDF5IO>(path);
+    hdf5io->open();
+
+    // Create a compound datatype
+    H5::CompType compoundType(sizeof(double) * 2);
+    compoundType.insertMember("real", 0, H5::PredType::NATIVE_DOUBLE);
+    compoundType.insertMember(
+        "imag", sizeof(double), H5::PredType::NATIVE_DOUBLE);
+
+    // Create dataset with compound type directly using HDF5 C++ API
+    H5::H5File file(path, H5F_ACC_RDWR);
+    hsize_t dims[1] = {5};
+    H5::DataSpace dataspace(1, dims);
+    H5::DataSet dataset =
+        file.createDataSet("ComplexData", compoundType, dataspace);
+
+    // Attempt to read the dataset - should throw an exception
+    REQUIRE_THROWS_AS(hdf5io->readDataset("/ComplexData"), std::runtime_error);
+
+    hdf5io->close();
   }
 }
 

--- a/tests/testRegisteredType.cpp
+++ b/tests/testRegisteredType.cpp
@@ -10,6 +10,40 @@
 
 using namespace AQNWB::NWB;
 
+// Test class with custom type name
+class CustomNameType : public RegisteredType
+{
+public:
+  CustomNameType(const std::string& path, std::shared_ptr<IO::BaseIO> io)
+      : RegisteredType(path, io)
+  {
+  }
+
+  virtual std::string getTypeName() const override { return "CustomType"; }
+  virtual std::string getNamespace() const override { return "test"; }
+};
+
+// Test class with field definitions
+class TestFieldType : public RegisteredType
+{
+public:
+  TestFieldType(const std::string& path, std::shared_ptr<IO::BaseIO> io)
+      : RegisteredType(path, io)
+  {
+  }
+
+  virtual std::string getTypeName() const override { return "TestFieldType"; }
+  virtual std::string getNamespace() const override { return "test"; }
+
+  DEFINE_FIELD(testAttribute,
+               AttributeField,
+               int32_t,
+               "test_attr",
+               "Test attribute field")
+  DEFINE_FIELD(
+      testDataset, DatasetField, float, "test_dataset", "Test dataset field")
+};
+
 TEST_CASE("RegisterType", "[base]")
 {
   SECTION("test that the registry is working")
@@ -27,23 +61,14 @@ TEST_CASE("RegisterType", "[base]")
     auto registry = RegisteredType::getRegistry();
     auto factoryMap = RegisteredType::getFactoryMap();
     // TODO we are checking for at least 10 registered types because that is how
-    // many
-    //      were defined at the time of implementation of this test. We know we
-    //      will add more, but we would like to avoid having to update this test
-    //      every time, so we are only checking for at least 10
+    // many were defined at the time of implementation of this test. We know we
+    // will add more, but we would like to avoid having to update this test
+    // every time, so we are only checking for at least 10
     REQUIRE(registry.size() >= 10);
     REQUIRE(factoryMap.size() >= 10);
     REQUIRE(registry.size() == factoryMap.size());
 
     // Test that we can indeed instantiate all registered types
-    // This also ensures that each factory function works correctly,
-    // and hence, that  all subtypes implement the expected constructor
-    // for the RegisteredType::create method. This is similar to
-    // checking:
-    // for (const auto& pair : factoryMap) {
-    //    auto instance = pair.second(examplePath, io);
-    //    REQUIRE(instance != nullptr);
-    // }
     std::cout << "Registered Types:" << std::endl;
     for (const auto& entry : factoryMap) {
       const std::string& subclassFullName = entry.first;
@@ -73,6 +98,9 @@ TEST_CASE("RegisterType", "[base]")
 
       // Check that the examplePath is set as expected
       REQUIRE(instance->getPath() == examplePath);
+
+      // Test getFullName
+      REQUIRE(instance->getFullName() == (typeNamespace + "::" + typeName));
     }
   }
 
@@ -136,5 +164,79 @@ TEST_CASE("RegisterType", "[base]")
     auto readTS = AQNWB::NWB::RegisteredType::create(examplePath, io);
     std::string readTSType = readContainer->getTypeName();
     REQUIRE(readTSType == "TimeSeries");
+  }
+
+  SECTION("test error handling for invalid type creation")
+  {
+    std::string filename = getTestFilePath("testInvalidType.h5");
+    std::shared_ptr<BaseIO> io = std::make_unique<IO::HDF5::HDF5IO>(filename);
+    std::string examplePath("/example/path");
+
+    // Test creating with non-existent type name
+    auto invalidInstance =
+        RegisteredType::create("invalid::Type", examplePath, io);
+    REQUIRE(invalidInstance == nullptr);
+
+    // Test creating with empty type name
+    auto emptyInstance = RegisteredType::create("", examplePath, io);
+    REQUIRE(emptyInstance == nullptr);
+
+    // Test creating with malformed type name (missing namespace)
+    auto malformedInstance =
+        RegisteredType::create("NoNamespace", examplePath, io);
+    REQUIRE(malformedInstance == nullptr);
+  }
+
+  SECTION("test custom type name")
+  {
+    std::string filename = getTestFilePath("testCustomType.h5");
+    std::shared_ptr<BaseIO> io = std::make_unique<IO::HDF5::HDF5IO>(filename);
+    std::string examplePath("/example/path");
+
+    // Create instance of custom named type
+    auto customInstance = std::make_shared<CustomNameType>(examplePath, io);
+    REQUIRE(customInstance != nullptr);
+    REQUIRE(customInstance->getTypeName() == "CustomType");
+    REQUIRE(customInstance->getNamespace() == "test");
+    REQUIRE(customInstance->getFullName() == "test::CustomType");
+  }
+
+  SECTION("test field definitions")
+  {
+    std::string filename = getTestFilePath("testFields.h5");
+    std::shared_ptr<BaseIO> io = std::make_unique<IO::HDF5::HDF5IO>(filename);
+    io->open();
+    std::string examplePath("/test_fields");
+
+    // Create test instance
+    auto testInstance = std::make_shared<TestFieldType>(examplePath, io);
+    REQUIRE(testInstance != nullptr);
+
+    // Create parent group
+    io->createGroup(examplePath);
+
+    // Create test data
+    const int32_t attrValue = 42;
+    const std::vector<float> datasetValues = {1.0f, 2.0f, 3.0f};
+
+    // Write test data
+    io->createAttribute(
+        BaseDataType::I32, &attrValue, examplePath, "test_attr");
+    io->createArrayDataSet(BaseDataType::F32,
+                           SizeArray {3},
+                           SizeArray {3},
+                           examplePath + "/test_dataset");
+
+    // Test attribute field
+    auto attrWrapper = testInstance->testAttribute();
+    REQUIRE(attrWrapper != nullptr);
+    auto attrData = attrWrapper->values();
+    REQUIRE(attrData.data[0] == attrValue);
+
+    // Test dataset field
+    auto datasetWrapper = testInstance->testDataset();
+    REQUIRE(datasetWrapper != nullptr);
+
+    io->close();
   }
 }


### PR DESCRIPTION
This PR is to prepare for #130 

*  Changed the `getGroupObjects` method to `getStorageObjects` to allow for more general lookup of groups, datasets, and attributes. The current method is limited to look-up of groups within a group. The updated `getStorageObjects` now supports: 1) lookup starting from datasets and groups and 2) retrieval of groups, datasets, and attributes, 3) allows the user to specify what types of storage objects to retrieve. 
* Fixed an issue in the `findTypes` function, which previously only looked at `Groups` so typed objects that were datasets (e.g., `VectorData`) would have been ignored. 
* Added unit tests for `findTypes` and missing tests for `RegisteredType` and `HDF5IO`
* Added new `RegisteredType::readField` function for reading arbitrary dataset and attribute fields
* Added second variant of  the `RegisteredType::readField` method to allow reading of arbitrary fields that are itself instances of `RegisteredType`, such as, reading `VectorData` from a `DynamicTable` or reading `ElectricalSeries` from an `NWBFile`

Fix #133 
Fix #131