### PR TITLE
Remove unused parameter `VectorData.m_description`

### DIFF
--- a/src/nwb/hdmf/table/VectorData.hpp
+++ b/src/nwb/hdmf/table/VectorData.hpp
@@ -65,11 +65,5 @@ public:
                std::string,
                "description",
                Description of what these vectors represent)
-
-private:
-  /**
-   * @brief Description of VectorData.
-   */
-  std::string m_description;
 };
 }  // namespace AQNWB::NWB


### PR DESCRIPTION
`VectorData.m_description` is not being used. I believe this is a leftover from when `description` was being passed to the constructor instead of the `initialize` method. 