### PR TITLE
Fix ElectricalSeries->electrodes dataset write and add tests

### DIFF
--- a/src/nwb/ecephys/ElectricalSeries.cpp
+++ b/src/nwb/ecephys/ElectricalSeries.cpp
@@ -43,10 +43,10 @@ void ElectricalSeries::initialize(const IO::BaseDataType& dataType,
   this->m_channelVector = channelVector;
 
   // setup variables based on number of channels
-  std::vector<SizeType> electrodeInds(channelVector.size());
+  std::vector<int> electrodeInds(channelVector.size());
   std::vector<float> channelConversions(channelVector.size());
   for (size_t i = 0; i < channelVector.size(); ++i) {
-    electrodeInds[i] = channelVector[i].getGlobalIndex();
+    electrodeInds[i] = static_cast<int>(channelVector[i].getGlobalIndex());
     channelConversions[i] = channelVector[i].getConversion();
   }
   m_samplesRecorded = SizeArray(channelVector.size(), 0);
@@ -73,14 +73,13 @@ void ElectricalSeries::initialize(const IO::BaseDataType& dataType,
   // make electrodes dataset
   m_electrodesDataset = std::unique_ptr<IO::BaseRecordingData>(
       m_io->createArrayDataSet(IO::BaseDataType::I32,
-                               SizeArray {1},
+                               SizeArray {channelVector.size()},
                                chunkSize,
                                AQNWB::mergePaths(getPath(), "electrodes")));
 
-  m_electrodesDataset->writeDataBlock(
-      std::vector<SizeType>(1, channelVector.size()),
-      IO::BaseDataType::I32,
-      &electrodeInds[0]);
+  m_electrodesDataset->writeDataBlock(SizeArray {channelVector.size()},
+                                      IO::BaseDataType::I32,
+                                      &electrodeInds[0]);
   auto electrodesPath = AQNWB::mergePaths(getPath(), "electrodes");
   m_io->createCommonNWBAttributes(
       electrodesPath, "hdmf-common", "DynamicTableRegion");

--- a/src/nwb/ecephys/ElectricalSeries.hpp
+++ b/src/nwb/ecephys/ElectricalSeries.hpp
@@ -109,6 +109,17 @@ public:
                Base unit of measurement for working with the data. 
                This value is fixed to volts)
 
+  DEFINE_FIELD(readElectrodes,
+               DatasetField,
+               int,
+               "electrodes",
+               The electrodes that generated this electrical series.)
+
+  DEFINE_FIELD(readElectrodesDescription,
+               AttributeField,
+               std::string,
+               "electrodes/description",
+               The electrodes that generated this electrical series.)
 private:
   /**
    * @brief The number of samples already written per channel.


### PR DESCRIPTION
The `ElectricalSeries->electrodes` dataset was being written incorrectly due to an incorrect data type. I updated the data type and added tests for write/read of this `ElectricalSeries->electrodes` dataset to avoid this issue in the future.