### PR TITLE
Add support for hdf5 filters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(
     src/Channel.cpp
     src/io/hdf5/HDF5IO.cpp
     src/io/hdf5/HDF5RecordingData.cpp
+    src/io/hdf5/HDF5ArrayDataSetConfig.cpp
     src/nwb/NWBFile.cpp
     src/nwb/RecordingContainers.cpp
     src/nwb/RegisteredType.cpp

--- a/docs/pages/userdocs/hdf5io.dox
+++ b/docs/pages/userdocs/hdf5io.dox
@@ -3,7 +3,22 @@
  *
  * \tableofcontents
  *
- * \section hdf5io_chunking Chunking
+ * \section hdf5io_data_layout Optimizing Data Layout 
+ *
+ * HDF5 supports advanced I/O features for optimizing the layout of large data arrays
+ * via \ref hdf5io_chunking "Chunking" and \ref hdf5io_filters "I/O Filters". Below
+ * we discuss these features in more detail. The main classes involved in configuring
+ * chunking and I/O filters in HDF5 via AQNWB are: 
+ *
+ * - \ref AQNWB::IO::ArrayDataSetConfig "ArrayDataSetConfig" for configuring datasets
+ *   for write, including chunking settings. 
+ *    - \ref AQNWB::IO::HDF5::HDF5ArrayDataSetConfig "HDF5ArrayDataSetConfig" then extends the basic
+ *      \ref AQNWB::IO::ArrayDataSetConfig "ArrayDataSetConfig" to add HDF5-specific configurations, 
+ *      such as, support for configuring I/O filters (e.g., for compression)
+ * - \ref AQNWB::IO::HDF5::HDF5IO::createArrayDataSet "HDF5IO::createArrayDataSet" is the main 
+ *   method used for creating n-dimensional array datasets
+ *
+ * \subsection hdf5io_chunking Chunking
  *
  * For datasets intended for recording, `AqNWB` uses chunking to ensure the dataset
  * can be extended as new data arrives during the recording process.
@@ -19,7 +34,8 @@
  *    of a chunked dataset is accessed, only the relevant chunks are read or written,
  *    reducing the amount of I/O operations.
  * - **Compression**: Data within each chunk can be compressed independently, which can help
- *   to significant reduce data size, especially for datasets with redundancy.
+ *   to significant reduce data size, especially for datasets with redundancy (see \ref hdf5io_filters).
+ *
  *
  * \warning
  * Choosing a chunking configuration that does not align well with the desired read/write pattern
@@ -93,6 +109,36 @@
  * }
  * \enddot
  *
+ *
+ *
+ * \subsection hdf5io_filters I/O Filters and Compression 
+ *
+ * HDF5 filters are used to transform data as it is written to and read from the file.
+ * Filters are applied on a per-chunk basis (i.e., chunking is required to use filters), and 
+ * are typically used for compression or error detection.
+ * 
+ * Compression filters reduce the amount of storage space required for datasets by eliminating
+ * redundancy in the data. One commonly used compression filter is ``GZIP (DEFLATE)``  which 
+ * provides a good balance between compression ratio and speed. Multiple filters may be applied 
+ * simultaneously. E.g., the ``Shuffle`` filter can be used to rearrange the bytes in the data to
+ * improve the effectiveness of compression filters. By shuffling the data, redundancy within 
+ * the byte stream is increased, which can help improve compression ratios. For
+ * more information on the available filters in HDF5, please refer to the
+ * [HDF5 Data Pipeline Filters Documentation](https://support.hdfgroup.org/documentation/hdf5/latest/_h5_d__u_g.html#subsubsec_dataset_transfer_filter)
+ * by the HDF5 project. 
+ * 
+ * \subsection hdf5io_filters_usage Using Chunking and I/O Filters in AqNWB
+ * 
+ * When creating datasets, you can specify the filters to be applied using the 
+ * \ref AQNWB::IO::HDF5::HDF5ArrayDataSetConfig "HDF5ArrayDataSetConfig" class.
+ * The following example demonstrates how to configure and apply the GZIP and 
+ * Shuffle filters to a dataset. The \ref AQNWB::IO::HDF5::HDF5ArrayDataSetConfig "HDF5ArrayDataSetConfig" 
+ * class allows you to specify the data type, shape, chunking, and filters
+ * for the dataset. The \ref AQNWB::IO::HDF5::HDF5IO::createArrayDataSet "HDF5IO::createArrayDataSet" 
+ * method them creates the dataset with the specified configuration.
+ *
+ * \snippet tests/examples/test_HDF5IO_examples.cpp example_HDF5_with_filters
+ * 
  *
  * \section hdf5io_swmr Single-Writer Multiple-Reader (SWMR) Mode
  *

--- a/docs/pages/userdocs/hdf5io.dox
+++ b/docs/pages/userdocs/hdf5io.dox
@@ -15,6 +15,9 @@
  *    - \ref AQNWB::IO::HDF5::HDF5ArrayDataSetConfig "HDF5ArrayDataSetConfig" then extends the basic
  *      \ref AQNWB::IO::ArrayDataSetConfig "ArrayDataSetConfig" to add HDF5-specific configurations, 
  *      such as, support for configuring I/O filters (e.g., for compression)
+ *    - \ref AQNWB::IO::HDF5::HDF5FilterConfig "HDF5FilterConfig" is used with 
+ *           \ref AQNWB::IO::HDF5::HDF5ArrayDataSetConfig "HDF5ArrayDataSetConfig" to configure
+ *           a single I/O filter.
  * - \ref AQNWB::IO::HDF5::HDF5IO::createArrayDataSet "HDF5IO::createArrayDataSet" is the main 
  *   method used for creating n-dimensional array datasets
  *

--- a/src/io/BaseIO.hpp
+++ b/src/io/BaseIO.hpp
@@ -160,6 +160,11 @@ public:
                      const SizeArray& chunking);
 
   /**
+   * @brief Virtual destructor to ensure proper cleanup in derived classes.
+   */
+  virtual ~ArrayDataSetConfig() = default;
+
+  /**
    * @brief Returns the data type of the dataset.
    * @return The data type of the dataset.
    */

--- a/src/io/hdf5/HDF5ArrayDataSetConfig.cpp
+++ b/src/io/hdf5/HDF5ArrayDataSetConfig.cpp
@@ -1,0 +1,36 @@
+#include "io/hdf5/HDF5ArrayDataSetConfig.hpp"
+
+using namespace AQNWB::IO::HDF5;
+
+HDF5FilterConfig::HDF5FilterConfig(H5Z_filter_t filter_id,
+                                   unsigned int cd_nelmts,
+                                   const unsigned int* cd_values)
+    : filter_id(filter_id)
+    , cd_nelmts(cd_nelmts)
+    , cd_values(cd_values, cd_values + cd_nelmts)
+{
+}
+
+HDF5ArrayDataSetConfig::HDF5ArrayDataSetConfig(const BaseDataType& type,
+                                               const SizeArray& shape,
+                                               const SizeArray& chunking)
+    : ArrayDataSetConfig(type, shape, chunking)
+{
+}
+
+void HDF5ArrayDataSetConfig::addFilter(H5Z_filter_t filter_id,
+                                       unsigned int cd_nelmts,
+                                       const unsigned int* cd_values)
+{
+  m_filters.emplace_back(filter_id, cd_nelmts, cd_values);
+}
+
+void HDF5ArrayDataSetConfig::addFilter(const HDF5FilterConfig& filter)
+{
+  m_filters.push_back(filter);
+}
+
+const std::vector<HDF5FilterConfig>& HDF5ArrayDataSetConfig::getFilters() const
+{
+  return m_filters;
+}

--- a/src/io/hdf5/HDF5ArrayDataSetConfig.hpp
+++ b/src/io/hdf5/HDF5ArrayDataSetConfig.hpp
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <vector>
+
+#include <H5Ppublic.h>
+
+#include "io/BaseIO.hpp"
+
+/*!
+ * \namespace AQNWB::HDF5
+ * \brief Namespace for all components of the HDF5 I/O backend
+ */
+namespace AQNWB::IO::HDF5
+{
+
+/**
+ * @brief The configuration for an HDF5 filter
+ *
+ * This class defines the properties of an HDF5 filter, including the filter ID,
+ * the number of elements in the client data array, and the client data array
+ * itself.
+ */
+class HDF5FilterConfig
+{
+public:
+  /**
+   * @brief Constructs an HDF5FilterConfig object with the specified filter ID,
+   * number of elements in the client data array, and the client data array.
+   * @param filter_id The ID of the filter.
+   * @param cd_nelmts The number of elements in the client data array.
+   * @param cd_values The client data array.
+   */
+  HDF5FilterConfig(H5Z_filter_t filter_id,
+                   unsigned int cd_nelmts,
+                   const unsigned int* cd_values);
+
+  // The ID of the filter
+  H5Z_filter_t filter_id;
+  // The number of elements in the client data array
+  unsigned int cd_nelmts;
+  // The client data array
+  std::vector<unsigned int> cd_values;
+};
+
+/**
+ * @brief The configuration for an HDF5 array dataset
+ *
+ * This class extends ArrayDataSetConfig to add additional configuration options
+ * for HDF5-specific features, such as filters.
+ */
+class HDF5ArrayDataSetConfig : public ArrayDataSetConfig
+{
+public:
+  /**
+   * @brief Constructs an HDF5ArrayDataSetConfig object with the specified type,
+   * shape, and chunking.
+   * @param type The data type of the dataset.
+   * @param shape The shape of the dataset.
+   * @param chunking The chunking of the dataset.
+   */
+  HDF5ArrayDataSetConfig(const BaseDataType& type,
+                         const SizeArray& shape,
+                         const SizeArray& chunking);
+
+  /**
+   * @brief Adds a filter to the dataset configuration.
+   * @param filter_id The ID of the filter.
+   * @param cd_nelmts The number of elements in the client data array.
+   * @param cd_values The client data array.
+   */
+  void addFilter(H5Z_filter_t filter_id,
+                 unsigned int cd_nelmts,
+                 const unsigned int* cd_values);
+
+  /**
+   * @brief Adds a filter to the dataset configuration using an HDF5FilterConfig
+   * object.
+   * @param filter The HDF5FilterConfig object.
+   */
+  void addFilter(const HDF5FilterConfig& filter);
+
+  /**
+   * @brief Returns the filters of the dataset.
+   * @return The filters of the dataset.
+   */
+  const std::vector<HDF5FilterConfig>& getFilters() const;
+
+private:
+  // The filters of the dataset
+  std::vector<HDF5FilterConfig> m_filters;
+};
+
+}  // namespace AQNWB::IO::HDF5

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(aqnwb_test
     testElementIdentifiers.cpp
     testFile.cpp
     testHDF5IO.cpp
+    testHDF5ArrayDataSetConfig.cpp
     testHDF5RecordingData.cpp
     testMisc.cpp
     testNWBFile.cpp

--- a/tests/testHDF5ArrayDataSetConfig.cpp
+++ b/tests/testHDF5ArrayDataSetConfig.cpp
@@ -1,0 +1,46 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "io/BaseIO.hpp"
+#include "io/hdf5/HDF5ArrayDataSetConfig.hpp"
+
+using namespace AQNWB;
+
+TEST_CASE("HDF5FilterConfig constructor", "[HDF5FilterConfig]")
+{
+  unsigned int cd_values[3] = {1, 2, 3};
+  IO::HDF5::HDF5FilterConfig filterConfig(H5Z_FILTER_DEFLATE, 3, cd_values);
+
+  REQUIRE(filterConfig.filter_id == H5Z_FILTER_DEFLATE);
+  REQUIRE(filterConfig.cd_nelmts == 3);
+  REQUIRE(filterConfig.cd_values.size() == 3);
+  REQUIRE(filterConfig.cd_values[0] == 1);
+  REQUIRE(filterConfig.cd_values[1] == 2);
+  REQUIRE(filterConfig.cd_values[2] == 3);
+}
+
+TEST_CASE("HDF5ArrayDataSetConfig addFilter", "[HDF5ArrayDataSetConfig]")
+{
+  IO::BaseDataType typeI32(IO::BaseDataType::T_I32, 1);
+  SizeArray shape = {10, 1000};
+  SizeArray chunking = {10, 100};
+  IO::HDF5::HDF5ArrayDataSetConfig config(typeI32, shape, chunking);
+
+  // Add GZIP compression filter (H5Z_FILTER_DEFLATE) with level 4
+  unsigned int gzip_level = 4;
+  config.addFilter(H5Z_FILTER_DEFLATE, 1, &gzip_level);
+
+  // Add shuffle filter (H5Z_FILTER_SHUFFLE)
+  config.addFilter(IO::HDF5::HDF5FilterConfig(H5Z_FILTER_SHUFFLE, 0, nullptr));
+
+  const auto& filters = config.getFilters();
+  REQUIRE(filters.size() == 2);
+
+  REQUIRE(filters[0].filter_id == H5Z_FILTER_DEFLATE);
+  REQUIRE(filters[0].cd_nelmts == 1);
+  REQUIRE(filters[0].cd_values.size() == 1);
+  REQUIRE(filters[0].cd_values[0] == gzip_level);
+
+  REQUIRE(filters[1].filter_id == H5Z_FILTER_SHUFFLE);
+  REQUIRE(filters[1].cd_nelmts == 0);
+  REQUIRE(filters[1].cd_values.size() == 0);
+}


### PR DESCRIPTION
Fix #77 

- [X] Created new `HDF5ArrayDataSetConfig` and `HDF5FilterConfig` class for configuring HDF5 filter settings and added unit tests
- [X] Updated `HDF5IO::createArrayDataSet` to support optional HDF5IO filters and added unit tests
- [X] Added user documentation and example for configuring I/O filters and compression