### PR TITLE
Simply search for neurodata_type objects via RegisteredType

### DIFF
--- a/src/io/BaseIO.cpp
+++ b/src/io/BaseIO.cpp
@@ -55,7 +55,8 @@ Status BaseIO::createCommonNWBAttributes(const std::string& path,
 std::unordered_map<std::string, std::string> BaseIO::findTypes(
     const std::string& starting_path,
     const std::unordered_set<std::string>& types,
-    SearchMode search_mode) const
+    SearchMode search_mode,
+    bool exlude_starting_path) const
 {
   std::unordered_map<std::string, std::string> found_types;
 
@@ -92,13 +93,19 @@ std::unordered_map<std::string, std::string> BaseIO::findTypes(
               namespace_attr.data[0] + "::" + neurodata_type_attr.data[0];
 
           // Check if the full type matches any of the given types
-          if (types.find(full_type) != types.end()) {
-            found_types[current_path] = full_type;
+          bool exclude_start_conditon =
+              (exlude_starting_path && (current_path == starting_path));
+          if (types.find(full_type) != types.end() || types.empty()) {
+            if (!exclude_start_conditon) {
+              found_types[current_path] = full_type;
+            }
           }
 
           // If search_mode is CONTINUE_ON_TYPE, continue searching inside this
           // object
-          if (search_mode == SearchMode::CONTINUE_ON_TYPE) {
+          if (search_mode == SearchMode::CONTINUE_ON_TYPE
+              || exclude_start_conditon)
+          {
             // Get the list of objects inside the current group
             std::vector<std::pair<std::string, StorageObjectType>> objects =
                 getStorageObjects(current_path, StorageObjectType::Undefined);

--- a/src/io/BaseIO.cpp
+++ b/src/io/BaseIO.cpp
@@ -92,27 +92,34 @@ std::unordered_map<std::string, std::string> BaseIO::findTypes(
           std::string full_type =
               namespace_attr.data[0] + "::" + neurodata_type_attr.data[0];
 
-          // Check if the full type matches any of the given types
+          // Check if we should exclude the current path
           bool exclude_start_conditon =
               (exlude_starting_path && (current_path == starting_path));
+
+          // Check if the full type matches any of the given types
           if (types.find(full_type) != types.end() || types.empty()) {
+            // Ignore the starting path if exclude_starting_path is true
             if (!exclude_start_conditon) {
+              // Add the object's path and type to the found_types map
               found_types[current_path] = full_type;
             }
           }
 
           // If search_mode is CONTINUE_ON_TYPE, continue searching inside this
-          // object
+          // object or when the current path is the starting path and
+          // exlude_starting_path is true
           if (search_mode == SearchMode::CONTINUE_ON_TYPE
               || exclude_start_conditon)
           {
-            // Get the list of objects inside the current group
+            // Get the list of objects inside the current group to
+            // continue the search
             std::vector<std::pair<std::string, StorageObjectType>> objects =
                 getStorageObjects(current_path, StorageObjectType::Undefined);
             for (const auto& obj : objects) {
               if (obj.second == StorageObjectType::Group
                   || obj.second == StorageObjectType::Dataset)
               {
+                // Recursively continue the search
                 searchTypes(AQNWB::mergePaths(current_path, obj.first));
               }
             }

--- a/src/io/BaseIO.cpp
+++ b/src/io/BaseIO.cpp
@@ -66,7 +66,7 @@ std::unordered_map<std::string, std::string> BaseIO::findTypes(
     const std::string& starting_path,
     const std::unordered_set<std::string>& types,
     SearchMode search_mode,
-    bool exlude_starting_path) const
+    bool exclude_starting_path) const
 {
   std::unordered_map<std::string, std::string> found_types;
 
@@ -104,7 +104,7 @@ std::unordered_map<std::string, std::string> BaseIO::findTypes(
 
           // Check if we should exclude the current path
           bool exclude_start_conditon =
-              (exlude_starting_path && (current_path == starting_path));
+              (exclude_starting_path && (current_path == starting_path));
 
           // Check if the full type matches any of the given types
           if (types.find(full_type) != types.end() || types.empty()) {
@@ -117,7 +117,7 @@ std::unordered_map<std::string, std::string> BaseIO::findTypes(
 
           // If search_mode is CONTINUE_ON_TYPE, continue searching inside this
           // object or when the current path is the starting path and
-          // exlude_starting_path is true
+          // exclude_starting_path is true
           if (search_mode == SearchMode::CONTINUE_ON_TYPE
               || exclude_start_conditon)
           {

--- a/src/io/BaseIO.hpp
+++ b/src/io/BaseIO.hpp
@@ -333,7 +333,7 @@ public:
       const std::string& starting_path,
       const std::unordered_set<std::string>& types,
       SearchMode search_mode,
-      bool exlude_starting_path = false) const;
+      bool exclude_starting_path = false) const;
 
   /**
    * @brief Reads a dataset and determines the data type

--- a/src/io/BaseIO.hpp
+++ b/src/io/BaseIO.hpp
@@ -252,16 +252,28 @@ public:
    * determine its type and matches it against the given types.
    *
    * @param starting_path The path in the HDF5 file to start the search from.
-   * @param types The set of types to search for.
+   * @param types The set of types to search for. If and empty set is provided,
+   *              then all objects with an assigned type (i.e., object that have
+   *              a neurodata_type and namespace attributed) will be returned.
    * @param search_mode The search mode to use.
-   *
+   * @param exclude_starting_path If true, the starting path will not be
+   * included in the search and the resutlting output, but only its children
+   * will be searched. This also means, if the starting path is a typed object,
+   * then STOP_ON_TYPE will stop if exclude_starting_path=false but if
+   * exclude_starting_path=true then it will not stop the search at the
+   * starting_path but will continue until the next matching typed object is
+   * found. This is useful when we want to find all objects with a neurodata
+   * type object, but we are not interested in the object itself (e.g., when we
+   * have an unknonwn Container type and we want to find all registred fields
+   * that is owns)
    * @return An unordered map where each key is the path to an object and its
    * corresponding value is the type of the object.
    */
   virtual std::unordered_map<std::string, std::string> findTypes(
       const std::string& starting_path,
       const std::unordered_set<std::string>& types,
-      SearchMode search_mode) const;
+      SearchMode search_mode,
+      bool exlude_starting_path = false) const;
 
   /**
    * @brief Reads a dataset and determines the data type

--- a/src/io/BaseIO.hpp
+++ b/src/io/BaseIO.hpp
@@ -252,7 +252,7 @@ public:
    * determine its type and matches it against the given types.
    *
    * @param starting_path The path in the HDF5 file to start the search from.
-   * @param types The set of types to search for. If and empty set is provided,
+   * @param types The set of types to search for. If an empty set is provided,
    *              then all objects with an assigned type (i.e., object that have
    *              a neurodata_type and namespace attributed) will be returned.
    * @param search_mode The search mode to use.

--- a/src/io/BaseIO.hpp
+++ b/src/io/BaseIO.hpp
@@ -264,7 +264,7 @@ public:
    * starting_path but will continue until the next matching typed object is
    * found. This is useful when we want to find all objects with a neurodata
    * type object, but we are not interested in the object itself (e.g., when we
-   * have an unknonwn Container type and we want to find all registred fields
+   * have an unknown Container type and we want to find all registered fields
    * that is owns)
    * @return An unordered map where each key is the path to an object and its
    * corresponding value is the type of the object.

--- a/src/nwb/NWBFile.hpp
+++ b/src/nwb/NWBFile.hpp
@@ -88,7 +88,7 @@ public:
   bool isInitialized() const;
 
   /**
-   * @brief Finalizes the NWB file by closing it.
+   * @brief Finalizes the NWB file by closing the io object.
    */
   Status finalize();
 

--- a/src/nwb/RegisteredType.cpp
+++ b/src/nwb/RegisteredType.cpp
@@ -100,3 +100,10 @@ std::shared_ptr<AQNWB::NWB::RegisteredType> RegisteredType::create(
     return nullptr;
   }
 }
+
+std::unordered_map<std::string, std::string>
+RegisteredType::findOwnedRegisteredTypes(
+    const std::unordered_set<std::string>& types) const
+{
+  return m_io->findTypes(m_path, types, IO::SearchMode::STOP_ON_TYPE, true);
+}

--- a/src/nwb/RegisteredType.cpp
+++ b/src/nwb/RegisteredType.cpp
@@ -101,8 +101,7 @@ std::shared_ptr<AQNWB::NWB::RegisteredType> RegisteredType::create(
   }
 }
 
-std::unordered_map<std::string, std::string>
-RegisteredType::findOwnedRegisteredTypes(
+std::unordered_map<std::string, std::string> RegisteredType::findOwnedTypes(
     const std::unordered_set<std::string>& types) const
 {
   return m_io->findTypes(m_path, types, IO::SearchMode::STOP_ON_TYPE, true);

--- a/src/nwb/RegisteredType.hpp
+++ b/src/nwb/RegisteredType.hpp
@@ -256,6 +256,23 @@ public:
     return this->create(AQNWB::mergePaths(m_path, fieldPath), m_io);
   }
 
+  /**
+   * @brief Find all typed objects that are owned by this object, i.e.,
+   * objects that have a neurodata_type and namespace attribute and have
+   * this object as there closest parent with an assigned type.
+   *
+   * This is a shorthand for calling
+   * `getIO()->findTypes(m_path, types, IO::SearchMode::STOP_ON_TYPE, true);`
+   *
+   * @param types The set of types to search for. If an empty set is provided,
+   * then all objects with an assigned type (i.e., object that have a
+   * neurodata_type and namespace attributed) will be returned.
+   * @return An unordered map where each key is the path to an object and its
+   * corresponding value is the type of the object.
+   */
+  virtual std::unordered_map<std::string, std::string> findOwnedRegisteredTypes(
+      const std::unordered_set<std::string>& types = {}) const;
+
 protected:
   /**
    * @brief Register a subclass name and its factory function in the registry.

--- a/src/nwb/RegisteredType.hpp
+++ b/src/nwb/RegisteredType.hpp
@@ -270,7 +270,7 @@ public:
    * @return An unordered map where each key is the path to an object and its
    * corresponding value is the type of the object.
    */
-  virtual std::unordered_map<std::string, std::string> findOwnedRegisteredTypes(
+  virtual std::unordered_map<std::string, std::string> findOwnedTypes(
       const std::unordered_set<std::string>& types = {}) const;
 
 protected:

--- a/tests/testBaseIO.cpp
+++ b/tests/testBaseIO.cpp
@@ -118,5 +118,88 @@ TEST_CASE("Test findTypes functionality", "[BaseIO]")
     REQUIRE(result.size() == 1);
     REQUIRE(result["/testProcessingModule"] == "core::ProcessingModule");
   }
+
+  SECTION("Search for any type with empty set")
+  {
+    // Setup hierarchy
+    io.createGroup("/");
+    io.createAttribute("core", "/", "namespace");
+    io.createAttribute("NWBFile", "/", "neurodata_type");
+
+    io.createGroup("/testProcessingModule");
+    io.createAttribute("core", "/testProcessingModule", "namespace");
+    io.createAttribute(
+        "ProcessingModule", "/testProcessingModule", "neurodata_type");
+
+    auto result = io.findTypes("/", {}, SearchMode::CONTINUE_ON_TYPE);
+    REQUIRE(result.size() == 2);
+    REQUIRE(result["/"] == "core::NWBFile");
+    REQUIRE(result["/testProcessingModule"] == "core::ProcessingModule");
+
+    result = io.findTypes("/", {}, SearchMode::STOP_ON_TYPE);
+    REQUIRE(result.size() == 1);
+    REQUIRE(result["/"] == "core::NWBFile");
+
+    result = io.findTypes("/", {}, SearchMode::STOP_ON_TYPE, true);
+    REQUIRE(result.size() == 1);
+    REQUIRE(result["/testProcessingModule"] == "core::ProcessingModule");
+  }
+
+  SECTION("Test with exclude_starting_path=true")
+  {
+    // Setup hierarchy
+    io.createGroup("/");
+    io.createAttribute("core", "/", "namespace");
+    io.createAttribute("NWBFile", "/", "neurodata_type");
+
+    io.createGroup("/testProcessingModule");
+    io.createAttribute("core", "/testProcessingModule", "namespace");
+    io.createAttribute(
+        "ProcessingModule", "/testProcessingModule", "neurodata_type");
+
+    io.createGroup("/testProcessingModule/testTimeSeries");
+    io.createAttribute(
+        "core", "/testProcessingModule/testTimeSeries", "namespace");
+    io.createAttribute(
+        "TimeSeries", "/testProcessingModule/testTimeSeries", "neurodata_type");
+
+    // If we exclude the starting path, then we should not find any NWBFile
+    // types
+    auto result =
+        io.findTypes("/", {"core::NWBFile"}, SearchMode::STOP_ON_TYPE, true);
+    REQUIRE(result.size() == 0);
+
+    // If we exclude the starting path but search for any type, then we should
+    // still find the ProcessingModule type as the next typed object below the
+    // root
+    result = io.findTypes("/", {}, SearchMode::STOP_ON_TYPE, true);
+    REQUIRE(result.size() == 1);
+    REQUIRE(result["/testProcessingModule"] == "core::ProcessingModule");
+
+    // If we exclude the starting path, then we should still find the
+    // ProcessingModule type
+    result = io.findTypes(
+        "/", {"core::ProcessingModule"}, SearchMode::STOP_ON_TYPE, true);
+    REQUIRE(result.size() == 1);
+    REQUIRE(result["/testProcessingModule"] == "core::ProcessingModule");
+
+    // If we exclude the starting path, then we should still find the
+    // ProcessingModule and the TimeSeries type if search for any type and
+    // ContineOnType is used
+    result = io.findTypes("/", {}, SearchMode::CONTINUE_ON_TYPE, true);
+    REQUIRE(result.size() == 2);
+    REQUIRE(result["/testProcessingModule"] == "core::ProcessingModule");
+    REQUIRE(result["/testProcessingModule/testTimeSeries"]
+            == "core::TimeSeries");
+
+    // If we include the starting path and using ContineOnType, then we should
+    // find all types
+    result = io.findTypes("/", {}, SearchMode::CONTINUE_ON_TYPE, false);
+    REQUIRE(result.size() == 3);
+    REQUIRE(result["/"] == "core::NWBFile");
+    REQUIRE(result["/testProcessingModule"] == "core::ProcessingModule");
+    REQUIRE(result["/testProcessingModule/testTimeSeries"]
+            == "core::TimeSeries");
+  }
   io.close();
 }

--- a/tests/testDynamicTable.cpp
+++ b/tests/testDynamicTable.cpp
@@ -168,7 +168,7 @@ TEST_CASE("DynamicTable", "[table]")
     }
   }
 
-  SECTION("test DynamicTable.findOwnedRegisteredTypes")
+  SECTION("test DynamicTable.findOwnedTypes")
   {
     std::string path = getTestFilePath("testDynamicTableFindOwned.h5");
     std::shared_ptr<BaseIO> io = createIO("HDF5", path);
@@ -208,7 +208,7 @@ TEST_CASE("DynamicTable", "[table]")
     io->flush();
 
     // Find all typed objects that are owned by this object
-    auto types = table.findOwnedRegisteredTypes();
+    auto types = table.findOwnedTypes();
     REQUIRE(types.size() == 2);
     REQUIRE(types["/test_table/id"] == "hdmf-common::ElementIdentifiers");
     REQUIRE(types["/test_table/col1"] == "hdmf-common::VectorData");

--- a/tests/testDynamicTable.cpp
+++ b/tests/testDynamicTable.cpp
@@ -183,10 +183,11 @@ TEST_CASE("DynamicTable", "[table]")
     std::vector<std::string> values = {"value1", "value2", "value3"};
     SizeArray dataShape = {values.size()};
     SizeArray chunking = {values.size()};
-    auto columnDataset = io->createArrayDataSet(
-        BaseDataType::V_STR, dataShape, chunking, tablePath + "/col1");
+    IO::ArrayDataSetConfig strConfig(BaseDataType::V_STR, dataShape, chunking);
+    std::string columnPath = mergePaths(tablePath, "col1");
+    auto columnDataset = io->createArrayDataSet(strConfig, columnPath);
     auto vectorData =
-        std::make_unique<NWB::VectorData<std::string>>(tablePath + "/col1", io);
+        std::make_unique<NWB::VectorData<std::string>>(columnPath, io);
     vectorData->initialize(std::move(columnDataset), "Column 1");
     status = table.addColumn(vectorData, values);
     REQUIRE(status == Status::Success);
@@ -195,10 +196,11 @@ TEST_CASE("DynamicTable", "[table]")
     std::vector<int> ids = {1, 2, 3};
     SizeArray idShape = {ids.size()};
     SizeArray idChunking = {ids.size()};
-    auto idDataset = io->createArrayDataSet(
-        BaseDataType::I32, idShape, idChunking, tablePath + "/id");
-    auto elementIDs =
-        std::make_unique<NWB::ElementIdentifiers>(tablePath + "/id", io);
+
+    std::string idPath = mergePaths(tablePath, "id");
+    IO::ArrayDataSetConfig i32Config(BaseDataType::I32, idShape, idChunking);
+    auto idDataset = io->createArrayDataSet(i32Config, idPath);
+    auto elementIDs = std::make_unique<NWB::ElementIdentifiers>(idPath, io);
     elementIDs->initialize(std::move(idDataset));
     status = table.setRowIDs(elementIDs, ids);
     REQUIRE(status == Status::Success);

--- a/tests/testNWBFile.cpp
+++ b/tests/testNWBFile.cpp
@@ -55,8 +55,13 @@ TEST_CASE("initialize", "[nwb]")
   initStatus = nwbfile.initialize(generateUuid());
   REQUIRE(initStatus == Status::Success);
   REQUIRE(nwbfile.isInitialized());
+
+  // Since we didn't create any typed objects within the NWBFile, we should
+  // have no owned types
+  auto result = nwbfile.findOwnedRegisteredTypes();
+  REQUIRE(result.size() == 0);
+
   nwbfile.finalize();
-  io->close();
 }
 
 TEST_CASE("createElectricalSeries", "[nwb]")
@@ -122,6 +127,17 @@ TEST_CASE("createElectricalSeries", "[nwb]")
     REQUIRE(((pair.first == "/acquisition/esdata1")
              || (pair.first == "/acquisition/esdata0")));
   }
+
+  // Check that we can find all the types that we created
+  // - /general/extracellular_ephys/array0 : core::ElectrodeGroup
+  // - /general/devices/array1 : core::Device
+  // - /general/extracellular_ephys/electrodes : core::DynamicTable
+  // - /acquisition/esdata1 : core::ElectricalSeries
+  // - /general/devices/array0 : core::Device
+  // - /general/extracellular_ephys/array1 : core::ElectrodeGroup
+  // - /acquisition/esdata0 : core::ElectricalSeries
+  auto result = nwbfile.findOwnedRegisteredTypes();
+  REQUIRE(result.size() == 7);
 
   // finalize the nwb file
   nwbfile.finalize();
@@ -196,6 +212,7 @@ TEST_CASE("createMultipleEcephysDatasets", "[nwb]")
   }
 
   nwbfile.finalize();
+  io->close();
 }
 
 TEST_CASE("createAnnotationSeries", "[nwb]")
@@ -250,6 +267,7 @@ TEST_CASE("createAnnotationSeries", "[nwb]")
   }
 
   nwbfile.finalize();
+  io->close();
 }
 
 TEST_CASE("setCanModifyObjectsMode", "[nwb]")
@@ -284,4 +302,5 @@ TEST_CASE("setCanModifyObjectsMode", "[nwb]")
 
   // stop recording
   nwbfile.finalize();
+  io->close();
 }

--- a/tests/testNWBFile.cpp
+++ b/tests/testNWBFile.cpp
@@ -362,7 +362,6 @@ TEST_CASE("createMultipleEcephysDatasets", "[nwb]")
   }
 
   nwbfile.finalize();
-  io->close();
 }
 
 TEST_CASE("createAnnotationSeries", "[nwb]")
@@ -418,7 +417,6 @@ TEST_CASE("createAnnotationSeries", "[nwb]")
   }
 
   nwbfile.finalize();
-  io->close();
 }
 
 TEST_CASE("setCanModifyObjectsMode", "[nwb]")
@@ -459,5 +457,4 @@ TEST_CASE("setCanModifyObjectsMode", "[nwb]")
 
   // stop recording
   nwbfile.finalize();
-  io->close();
 }

--- a/tests/testNWBFile.cpp
+++ b/tests/testNWBFile.cpp
@@ -58,7 +58,7 @@ TEST_CASE("initialize", "[nwb]")
 
   // Since we didn't create any typed objects within the NWBFile, we should
   // have no owned types
-  auto result = nwbfile.findOwnedRegisteredTypes();
+  auto result = nwbfile.findOwnedTypes();
   REQUIRE(result.size() == 0);
 
   nwbfile.finalize();
@@ -136,7 +136,7 @@ TEST_CASE("createElectricalSeries", "[nwb]")
   // - /general/devices/array0 : core::Device
   // - /general/extracellular_ephys/array1 : core::ElectrodeGroup
   // - /acquisition/esdata0 : core::ElectricalSeries
-  auto result = nwbfile.findOwnedRegisteredTypes();
+  auto result = nwbfile.findOwnedTypes();
   REQUIRE(result.size() == 7);
 
   // finalize the nwb file

--- a/tests/testVectorData.cpp
+++ b/tests/testVectorData.cpp
@@ -239,8 +239,9 @@ TEST_CASE("VectorData", "[base]")
     io->open();
 
     // create BaseRecordingData to pass to VectorData.initialize
+    IO::ArrayDataSetConfig config(dataType, dataShape, chunking);
     std::unique_ptr<BaseRecordingData> columnDataset =
-        io->createArrayDataSet(dataType, dataShape, chunking, dataPath);
+        io->createArrayDataSet(config, dataPath);
 
     // setup VectorData object
     NWB::VectorData<int> columnVectorData = NWB::VectorData<int>(dataPath, io);

--- a/tests/testVectorData.cpp
+++ b/tests/testVectorData.cpp
@@ -217,7 +217,7 @@ TEST_CASE("VectorData", "[base]")
     readio->close();
   }
 
-  SECTION("test VectorData.findOwnedRegisteredTypes")
+  SECTION("test VectorData.findOwnedTypes")
   {
     // Prepare test data
     SizeType numSamples = 10;
@@ -250,7 +250,7 @@ TEST_CASE("VectorData", "[base]")
     io->flush();
 
     // Find all typed objects that are owned by this object
-    auto types = columnVectorData.findOwnedRegisteredTypes();
+    auto types = columnVectorData.findOwnedTypes();
     REQUIRE(types.size() == 0);
 
     io->close();


### PR DESCRIPTION
Fix #173
Fix #174 

- [X] Updated `BaseIO.findTypes` to add a `bool exlude_starting_path` option to allow us to search for all objects within a type but not include the ``starting_path`` itself. This also prevents `STOP_ON_TYPE` from stopping at the `starting_path`
- [X] Updated `BaseIO.findTypes` to allow `types={}` as input to indicate that we want to find any object with a `neurodata_type` independent of what the specific type is.
- [X] Added `RegisteredType.findOwnedTypes` to allow us to find all neurodata_type objects that are owned by the current object, i.e., these are the children with a neurodata_type that have this object as their closest parent with a neurodata_type
- [X] Updated unit tests