### PR TITLE
Support use of std::variant and std::visit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ CMakeUserPresets.json
 compile_commands.json
 CMakeCache.txt
 CMakeFiles/
+
+# locally install libraries 
+libs/

--- a/docs/pages/devdocs/read_design.dox
+++ b/docs/pages/devdocs/read_design.dox
@@ -52,14 +52,19 @@
  *     \ref AQNWB::IO::DataBlock "DataBlock" is templated on the specific data type, and
  *     stores the \ref AQNWB::IO::DataBlock::data "data" as an appropriately typed 1-dimensional 
  *     ``std::vector`` along with the \ref AQNWB::IO::DataBlock::shape "shape" of the data.
- * 6. ``BOOST::multi_array``
+ * 6. [BOOST::multi_array](https://www.boost.org/doc/libs/1_83_0/libs/multi_array/doc/user.html)
  *   -  ``BOOST::multi_array`` can also be used simplify access to multi-dimensional data.
  *      The \ref AQNWB::IO::DataBlock::as_multi_array "DataBlock.as_multi_array"
  *      convenience method generates a ``boost::const_multi_array_ref<DTYPE, NDIMS>`` for us.
+ * 7. [std::variant](https://en.cppreference.com/w/cpp/utility/variant)
+ *   - ``std::variant` can also be used when we want to compute on the data in a type-safe
+ *     manner but do not know the data type beforehand (e.g., when reading NWB data from a
+ *     third party).
  *
  * \note
- * The \ref AQNWB::IO::DataBlock::fromGeneric "DataBlock.fromGeneric" and
- * \ref AQNWB::IO::DataBlock::as_multi_array "DataBlock.as_multi_array" methods use casting
+ * The \ref AQNWB::IO::DataBlock::fromGeneric "DataBlock.fromGeneric",
+ * \ref AQNWB::IO::DataBlock::as_multi_array "DataBlock.as_multi_array",
+ * and \ref AQNWB::IO::DataBlockGeneric::as_variant "DataBlockGeneric.as_variant" methods use casting
  * and referencing to transform the data without making additional copies
  * of the data.
  *
@@ -369,10 +374,14 @@
  * \note
  * In most cases, we should not need runtime checking of types in the context of
  * specific data acquisition systems. This is mostly likely relevant if one wants to consume
- * arbitrary NWB files that may use different data types. One approach to implement
- * behavior for types determined at runtime is to define a mapping of the type
- * information to the corresponding statically type functionality, e.g., via
- * ``switch/case`` logic or by using a map for lookup, such as:
+ * arbitrary NWB files that may use different data types. One approach is to use `std::variant`
+ * as described in \ref read_example_variant_data. Using `std::variant` helps avoid
+ * complex code for checking data types at runtime. <br>
+ * If for some reason we cannot easily use the `std:variant`
+ * approach (e.g., in case we need to use data types not natively supported by AqNWB), 
+ * an alternative approach would be to define a mapping of the type information to the 
+ * corresponding statically typedVector functionality, e.g., via `switch/case`` logic or 
+ * by using a map for lookup, such as:
  * \code{.cpp}
  * DataBlockGeneric dataValuesGeneric = readDataWrapperGeneric->valuesGeneric();
  * // Map to associate std::type_index with corresponding type-specific functions

--- a/docs/pages/userdocs/read.dox
+++ b/docs/pages/userdocs/read.dox
@@ -115,13 +115,6 @@
  *
  * \snippet tests/examples/test_ecephys_data_read.cpp example_read_only_stringattr_snippet
  *
- * \note
- * When working with data in AqNWB, you need to know the data type (e.g., `float`, `int`) at compile time
- * since C++ is a strongly typed language. For example, when using \ref AQNWB::IO::DataBlock "DataBlock",
- * you need to specify the data type. And if you want to use \ref AQNWB::IO::DataBlock::as_multi_array "DataBlock.as_multi_array",
- * you also need to know the number of dimensions at compile time.
- *
- * \par
  * \note 
  * For attributes, slicing is disabled at compile time since attributes are intended for small data only.
  *
@@ -155,6 +148,34 @@
  * however, because we do not specify the type, the function returns the object as a pointer 
  * of \ref AQNWB::NWB::RegisteredType "RegisteredType", that we can then subsequently cast to the 
  * approbriate type if necessary. 
+ *
+ * \subsection read_example_variant_data Working with fields with unknown data type 
+ *
+ * C++ is a statically typed language, i.e., we need to know the type of every variable at compile time. 
+ * This can be particularly challenging when reading data from disk where the data type may not be 
+ * known before-hand. AqNWB helps us here by allocating memory and determining data types for us 
+ * when reading data fields. However, when we want to compute on the data, we still need to know
+ * the data type, e.g., to use the typed \ref AQNWB::IO::DataBlock "DataBlock<DTYPE>" we need to know 
+ * the DTYPE.
+ *
+ * Using [std::variant](https://en.cppreference.com/w/cpp/utility/variant) with 
+ * [std::visit](https://en.cppreference.com/w/cpp/utility/variant/visit) (introduced in C++17) 
+ * provides an alternative approach, that can help us avoid having to write complex `switch/case` 
+ * statements to check for all possible types when we don't know the data type beforehand. 
+ * E.g., using `std::visit` we can define a set of functions to compute the mean for 
+ * any 1D `std::vector`:
+ *
+ * \snippet tests/examples/test_ecephys_data_read.cpp  example_compute_mean_from_variant
+ *
+ * Using \ref AQNWB::IO::DataBlockGeneric::as_variant "DataBlockGeneric::as_variant" we can then
+ * cast our data to a \ref AQNWB::IO::BaseDataType::BaseDataVectorVariant "BaseDataVectorVariant", 
+ * which is am `std::variant` representing a 1D `std::vector` containing values of any valid 
+ * \ref AQNWB::IO::BaseDataType "BaseDataType". We can then using our `compute_mean` methods to
+ * conveniently compute on the data without having to explicitly specify the type of the data 
+ * ourselves. 
+ *
+ * \snippet tests/examples/test_ecephys_data_read.cpp  example_use_std_variant_to_compute_on_data
+ * 
  *
  * \section read_further_reading Further reading
  * - \ref read_design_page discusses the underlying software design of AqNWB for data read 

--- a/src/io/BaseIO.hpp
+++ b/src/io/BaseIO.hpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <variant>
 #include <vector>
 
 #include <boost/multi_array.hpp>  // TODO move this and function def to the cpp file
@@ -89,6 +90,20 @@ public:
   {
     return type == other.type && typeSize == other.typeSize;
   }
+
+  // Variant data type for representing any 1D vector with BaseDataType values
+  using BaseDataVectorVariant = std::variant<std::monostate,
+                                             std::vector<uint8_t>,
+                                             std::vector<uint16_t>,
+                                             std::vector<uint32_t>,
+                                             std::vector<uint64_t>,
+                                             std::vector<int8_t>,
+                                             std::vector<int16_t>,
+                                             std::vector<int32_t>,
+                                             std::vector<int64_t>,
+                                             std::vector<float>,
+                                             std::vector<double>,
+                                             std::vector<std::string>>;
 };
 
 class DataBlockGeneric;

--- a/src/io/ReadIO.hpp
+++ b/src/io/ReadIO.hpp
@@ -90,6 +90,8 @@ public:
    *
    * This function casts the std::any data to an std::variant. This only
    * works for data blocks that store data types defined by BaseDataType.
+   * For other types an std::monostate will be returned instead if the
+   * data cannot be cast to a BaseDataType::BaseDataVectorVariant
    *
    * @return An std::variant containing the data.
    */

--- a/src/io/ReadIO.hpp
+++ b/src/io/ReadIO.hpp
@@ -10,6 +10,7 @@
 
 #include <boost/multi_array.hpp>  // TODO move this and function def to the cpp file
 
+#include "BaseIO.hpp"
 #include "Types.hpp"
 
 using StorageObjectType = AQNWB::Types::StorageObjectType;
@@ -75,11 +76,59 @@ public:
    */
   DataBlockGeneric(const std::any& inData,
                    const std::vector<SizeType>& inShape,
-                   const std::type_index& inTypeIndex)
+                   const std::type_index& inTypeIndex,
+                   const IO::BaseDataType baseDataType)
       : data(inData)
       , shape(inShape)
       , typeIndex(inTypeIndex)
+      , baseDataType(baseDataType)
   {
+  }
+
+  /**
+   * @brief Convert the data to an std::variant for convenient access.
+   *
+   * This function casts the std::any data to an std::variant. This only
+   * works for data blocks that store data types defined by BaseDataType.
+   *
+   * @return An std::variant containing the data.
+   */
+  BaseDataType::BaseDataVectorVariant as_variant() const
+  {
+    try {
+      switch (baseDataType.type) {
+        case BaseDataType::T_U8:
+          return std::any_cast<std::vector<uint8_t>>(data);
+        case BaseDataType::T_U16:
+          return std::any_cast<std::vector<uint16_t>>(data);
+        case BaseDataType::T_U32:
+          return std::any_cast<std::vector<uint32_t>>(data);
+        case BaseDataType::T_U64:
+          return std::any_cast<std::vector<uint64_t>>(data);
+        case BaseDataType::T_I8:
+          return std::any_cast<std::vector<int8_t>>(data);
+        case BaseDataType::T_I16:
+          return std::any_cast<std::vector<int16_t>>(data);
+        case BaseDataType::T_I32:
+          return std::any_cast<std::vector<int32_t>>(data);
+        case BaseDataType::T_I64:
+          return std::any_cast<std::vector<int64_t>>(data);
+        case BaseDataType::T_F32:
+          return std::any_cast<std::vector<float>>(data);
+        case BaseDataType::T_F64:
+          return std::any_cast<std::vector<double>>(data);
+        case BaseDataType::T_STR:
+          return std::any_cast<std::vector<std::string>>(data);
+        default:
+          return std::monostate {};
+      }
+    } catch (const std::bad_any_cast&) {
+      // If the actual type stored in `data` does not match the expected type
+      // based on `baseDataType`, a `std::bad_any_cast` exception will be
+      // thrown. In this case, we catch the exception and return
+      // `std::monostate` to indicate that the conversion failed.
+      return std::monostate {};
+    }
   }
 };
 

--- a/src/io/ReadIO.hpp
+++ b/src/io/ReadIO.hpp
@@ -86,12 +86,12 @@ public:
   }
 
   /**
-   * @brief Convert the data to an std::variant for convenient access.
+   * @brief Cast the data to an std::variant for convenient access.
    *
-   * This function casts the std::any data to an std::variant. This only
-   * works for data blocks that store data types defined by BaseDataType.
-   * For other types an std::monostate will be returned instead if the
-   * data cannot be cast to a BaseDataType::BaseDataVectorVariant
+   * This function casts the std::any data to an std::variant via an
+   * std::any_cast. This only works for data blocks that store data types
+   * defined by BaseDataType. For other types an std::monostate will be returned
+   * instead if the data cannot be cast to a BaseDataType::BaseDataVectorVariant
    *
    * @return An std::variant containing the data.
    */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(aqnwb_test
     testHDF5RecordingData.cpp
     testMisc.cpp
     testNWBFile.cpp
+    testReadIO.cpp
     testRecordingWorkflow.cpp
     testRegisteredType.cpp
     testTimeSeries.cpp

--- a/tests/testReadIO.cpp
+++ b/tests/testReadIO.cpp
@@ -1,0 +1,226 @@
+#include <any>
+#include <numeric>
+#include <stdexcept>
+#include <typeindex>
+#include <variant>
+#include <vector>
+
+#include <boost/multi_array.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
+#include "io/ReadIO.hpp"
+
+using namespace AQNWB::IO;
+
+// Helper function to compute the mean of a vector
+template<typename T>
+double compute_mean(const T& data)
+{
+  if (data.empty()) {
+    throw std::runtime_error("Data vector is empty");
+  }
+  double sum = std::accumulate(data.begin(), data.end(), 0.0);
+  return sum / data.size();
+}
+
+// Function to compute the mean using std::visit
+double compute_mean(const BaseDataType::BaseDataVectorVariant& variant)
+{
+  return std::visit(
+      [](auto&& arg) -> double
+      {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<T, std::monostate>) {
+          throw std::runtime_error("Invalid data type");
+        } else if constexpr (std::is_same_v<T, std::vector<std::string>>) {
+          throw std::runtime_error("Cannot compute mean of string data");
+        } else {
+          return compute_mean(arg);
+        }
+      },
+      variant);
+}
+
+TEST_CASE("DataBlock - Basic Functionality", "[DataBlock]")
+{
+  SECTION("Constructor and Accessors")
+  {
+    std::vector<int> data = {1, 2, 3, 4, 5};
+    std::vector<SizeType> shape = {5};
+
+    DataBlock<int> block(data, shape);
+
+    REQUIRE(block.data == data);
+    REQUIRE(block.shape == shape);
+    REQUIRE(block.typeIndex == typeid(int));
+  }
+
+  SECTION("Modification")
+  {
+    std::vector<int> data = {1, 2, 3, 4, 5};
+    std::vector<SizeType> shape = {5};
+
+    DataBlock<int> block(data, shape);
+    block.data[2] = 10;
+
+    REQUIRE(block.data[2] == 10);
+  }
+
+  SECTION("From Generic")
+  {
+    std::vector<int> data = {1, 2, 3, 4, 5};
+    std::vector<SizeType> shape = {5};
+    BaseDataType baseDataType = {BaseDataType::T_I32};
+
+    DataBlock<int> block(data, shape);
+    DataBlockGeneric genericBlock(
+        std::any(data), shape, typeid(int), baseDataType);
+
+    auto newBlock = DataBlock<int>::fromGeneric(genericBlock);
+
+    REQUIRE(newBlock.data == block.data);
+    REQUIRE(newBlock.shape == block.shape);
+  }
+}
+
+TEST_CASE("DataBlockGeneric - Basic Functionality", "[DataBlockGeneric]")
+{
+  SECTION("Constructor and Accessors")
+  {
+    std::vector<int> data = {1, 2, 3, 4, 5};
+    std::vector<SizeType> shape = {5};
+    BaseDataType baseDataType = {BaseDataType::T_I32};
+
+    DataBlock<int> block(data, shape);
+    DataBlockGeneric genericBlock(
+        std::any(data), shape, typeid(int), baseDataType);
+
+    REQUIRE(genericBlock.shape == shape);
+    REQUIRE(genericBlock.typeIndex == typeid(int));
+    REQUIRE(std::any_cast<std::vector<int>>(genericBlock.data) == data);
+
+    auto newBlock = DataBlock<int>::fromGeneric(genericBlock);
+    REQUIRE(newBlock.data == data);
+    REQUIRE(newBlock.shape == shape);
+  }
+}
+
+TEST_CASE("DataBlock - Edge Cases", "[DataBlock]")
+{
+  SECTION("Empty Data Block")
+  {
+    std::vector<int> data;
+    std::vector<SizeType> shape;
+
+    DataBlock<int> block(data, shape);
+
+    REQUIRE(block.data.empty());
+    REQUIRE(block.shape.empty());
+  }
+
+  SECTION("Multi-dimensional Data Block")
+  {
+    std::vector<int> data = {1, 2, 3, 4, 5, 6};
+    std::vector<SizeType> shape = {2, 3};
+
+    DataBlock<int> block(data, shape);
+
+    REQUIRE(block.data == data);
+    REQUIRE(block.shape == shape);
+  }
+}
+
+TEST_CASE("DataBlockGeneric - as_variant Method", "[DataBlockGeneric]")
+{
+  SECTION("Variant Conversion")
+  {
+    std::vector<int> data = {1, 2, 3, 4, 5};
+    std::vector<SizeType> shape = {5};
+    BaseDataType baseDataType = {BaseDataType::T_I32};
+
+    DataBlockGeneric genericBlock(
+        std::any(data), shape, typeid(int), baseDataType);
+
+    auto variant = genericBlock.as_variant();
+    REQUIRE(std::holds_alternative<std::vector<int>>(variant));
+    REQUIRE(std::get<std::vector<int>>(variant) == data);
+  }
+
+  SECTION("Unsupported Type")
+  {
+    std::vector<int> data = {1, 2, 3, 4, 5};
+    std::vector<SizeType> shape = {5};
+    BaseDataType baseDataType = {BaseDataType::T_STR};
+
+    DataBlockGeneric genericBlock(
+        std::any(data), shape, typeid(int), baseDataType);
+
+    auto variant = genericBlock.as_variant();
+    REQUIRE(std::holds_alternative<std::monostate>(variant));
+  }
+}
+
+TEST_CASE("DataBlockGeneric - Compute Mean with std::visit",
+          "[DataBlockGeneric]")
+{
+  SECTION("Compute Mean for Integer Data")
+  {
+    std::vector<int> data = {1, 2, 3, 4, 5};
+    std::vector<SizeType> shape = {5};
+    BaseDataType baseDataType = {BaseDataType::T_I32};
+
+    DataBlockGeneric genericBlock(
+        std::any(data), shape, typeid(int), baseDataType);
+
+    auto variant = genericBlock.as_variant();
+
+    double mean = compute_mean(variant);
+
+    REQUIRE(mean == Catch::Approx(3.0));
+  }
+
+  SECTION("Compute Mean for Float Data")
+  {
+    std::vector<float> data = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+    std::vector<SizeType> shape = {5};
+    BaseDataType baseDataType = {BaseDataType::T_F32};
+
+    DataBlockGeneric genericBlock(
+        std::any(data), shape, typeid(float), baseDataType);
+
+    auto variant = genericBlock.as_variant();
+
+    double mean = compute_mean(variant);
+
+    REQUIRE(mean == Catch::Approx(3.0));
+  }
+
+  SECTION("Compute Mean for Empty Data")
+  {
+    std::vector<int> data;
+    std::vector<SizeType> shape = {0};
+    BaseDataType baseDataType = {BaseDataType::T_I32};
+
+    DataBlockGeneric genericBlock(
+        std::any(data), shape, typeid(int), baseDataType);
+
+    auto variant = genericBlock.as_variant();
+
+    REQUIRE_THROWS_AS(compute_mean(variant), std::runtime_error);
+  }
+
+  SECTION("Compute Mean for String Data")
+  {
+    std::vector<std::string> data = {"a", "b", "c"};
+    std::vector<SizeType> shape = {3};
+    BaseDataType baseDataType = {BaseDataType::T_STR};
+
+    DataBlockGeneric genericBlock(
+        std::any(data), shape, typeid(std::string), baseDataType);
+
+    auto variant = genericBlock.as_variant();
+
+    REQUIRE_THROWS_AS(compute_mean(variant), std::runtime_error);
+  }
+}


### PR DESCRIPTION
To simplify analysis of data where the user may not know the data type until runtime (e.g., when reading data from DANDI) it would be nice to be able to load the data as an std::variant (at least for all the common data types that NWB uses). In this way users can use std::visit to implement analytics (e.g., to compute a mean) in a way that is agnostic to the specific data type. 

- [X] Added `BaseDataType::BaseDataVectorVariant` to define a `std::variant` that can represent a 1D `std::vector` of any supported `BaseDataType`
- [X] Added `DataBlockGeneric::as_variant` method to cast data to a  `BaseDataType::BaseDataVectorVariant` that we can compute on
- [X] Added unit tests for `DataBlock` and `DataBlockGeneric`
- [X] Updated data read example to show a  example where we compute the mean value for an `ElectricalSeries.data` using `std::variant` and `std::visit`
- [X] Updated the user and developer docs for read to discuss the use `std::variant`

Fix #172