### PR TITLE
Add demo to show how to implement and Extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,4 @@ demo/cmake-build-*/
 demo/inspect_electrical_series/*.nwb
 demo/*/Makefile
 demo/*/cmake_install.cmake
-
+demo/*/build

--- a/demo/labmetadata_extension_demo/CMakeLists.txt
+++ b/demo/labmetadata_extension_demo/CMakeLists.txt
@@ -1,0 +1,61 @@
+cmake_minimum_required(VERSION 3.15)
+project(labmetadata_extension_demo VERSION 0.1.0 LANGUAGES CXX)
+
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Allow configuring paths to dependencies
+set(AQNWB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../build/dev" CACHE PATH "Path to aqnwb build directory")
+set(HDF5_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../libs/hdf5_build/install/cmake" CACHE PATH "Path to HDF5 build directory")
+set(BOOST_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../libs/boost_1_82_0" CACHE PATH "Path to Boost root directory")
+
+# Find required dependencies
+find_package(HDF5 REQUIRED COMPONENTS CXX)
+find_package(Boost REQUIRED)
+
+# Add the executable
+add_executable(labmetadata_extension_demo 
+    src/main.cpp
+    src/LabMetaDataExtensionExample.cpp
+)
+
+# Include directories
+target_include_directories(labmetadata_extension_demo PRIVATE 
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+    ${HDF5_INCLUDE_DIRS}
+    ${Boost_INCLUDE_DIRS}
+)
+
+# Find the aqnwb library
+if(EXISTS "${AQNWB_DIR}/libaqnwb.a")
+    set(AQNWB_LIBRARY "${AQNWB_DIR}/libaqnwb.a")
+elseif(EXISTS "${AQNWB_DIR}/libaqnwb.so")
+    set(AQNWB_LIBRARY "${AQNWB_DIR}/libaqnwb.so")
+elseif(EXISTS "${AQNWB_DIR}/libaqnwb.dylib")
+    set(AQNWB_LIBRARY "${AQNWB_DIR}/libaqnwb.dylib")
+else()
+    message(FATAL_ERROR "Could not find aqnwb library in ${AQNWB_DIR}. Please build the main project first or set AQNWB_DIR to the correct path.")
+endif()
+
+# Link libraries
+target_link_libraries(labmetadata_extension_demo 
+    ${AQNWB_LIBRARY}
+    ${HDF5_CXX_LIBRARIES}
+    ${Boost_LIBRARIES}
+)
+
+# If on Windows, link bcrypt
+if(WIN32)
+    target_link_libraries(labmetadata_extension_demo bcrypt)
+endif()
+
+# Set the output directory
+set_target_properties(labmetadata_extension_demo PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin
+)
+
+# Install rules
+install(TARGETS labmetadata_extension_demo
+    RUNTIME DESTINATION bin
+)

--- a/demo/labmetadata_extension_demo/README.md
+++ b/demo/labmetadata_extension_demo/README.md
@@ -1,0 +1,85 @@
+# AqNWB LabMetaData Extension Demo
+
+1. **Define the data schema:** Here we use the schema from [ndx-labmetadata-example](https://github.com/NeurodataWithoutBorders/ndx-labmetadata-example/)
+    as an example. See the tutorial on [Extending NWB](https://nwb-overview.readthedocs.io/en/latest/extensions_tutorial/extensions_tutorial_home.html)
+    to learn more about how to create extensions and see the [Extensions for lab-specific metadata](https://nwb-overview.readthedocs.io/en/latest/extensions_tutorial/extension_examples/labmetadata_extension.html)
+    in particular for details on how to create the [ndx-labmetadata-example](https://github.com/NeurodataWithoutBorders/ndx-labmetadata-example/) extension schema.
+    For convenienve we downloaded just the schema YAML files to the `demo/labmetadata_extension_demo/spec` folder.  
+2. **Convert the schema files to C++**:  Run the `resources/generate_spec_files.py` script on your schema files to generate the necessary C++ header files.
+    ```
+    mkdir demo/labmetadata_extension_demo/src
+    python resources/generate_spec_files.py  demo/labmetadata_extension_demo/spec  demo/labmetadata_extension_demo/src
+    ``` 
+    This generates a new header file `ndx_labmetadata_example.hpp` in the `demo/labmetadata_extension_demo/src` folder. 
+
+3. **Create new RegisteredType classes:** Next we implement `RegisteredType` classes for every `neurodata_type` defined in the schema
+   following the tutorial on [Implementing a new Neurodata Type](https://neurodatawithoutborders.github.io/aqnwb/registered_type_page.html)
+   A few key steps to look  out for:
+   * **Use the right base class:**
+       * At the very least our class must inherit from `` AQNWB::NWB::RegisteredType``
+       * When the `neurodata_type` is a dataset then it is often useful to inherit from `Data` defined in `#include "nwb/hdmf/base/Data.hpp"` to inherit its base ``initalize`` and read methods.
+       * When the `neurodata_type` is a group  then it is often useful to inherit from  `Container` defined in `#include "nwb/hdmf/base/Container.hpp"` to inherit its base ``initalize`` and read methods.
+    * **Ensure REGISTER_SUBCLASS is called in the header file**
+    * **Ensure REGISTER_SUBCLASS_IMPL is called in the cpp file**
+    * Implement the setup of your data type for write in a function called `initialize` (and make sure to call the `initialize` of your parent class).
+    * Include approbriate `DEFINE_FIELD` and `DEFINE_REGISTERED_FIELD` definitions to simplify read 
+   
+4. **Use your extension in your application:** Here we create a simple `main.cpp` example script that demonstrated the use 
+   of our new ` LabMetaDataExtensionExample` type to write and read the example. 
+
+## Building and Running the Demo
+
+### Prerequisites
+
+Before building the demo, ensure you have the following dependencies installed:
+- CMake (version 3.15 or higher)
+- C++ compiler with C++17 support
+- HDF5 library with C++ support
+- Boost library
+
+### Build Instructions
+
+1. **Build the main AqNWB library** (if not already built):
+   ```bash
+   cd /path/to/aqnwb
+   mkdir -p build/dev
+   cd build/dev
+   cmake ../..
+   make
+   ```
+
+2. **Build the LabMetaData Extension Demo**:
+   ```bash
+   cd /path/to/aqnwb/demo/labmetadata_extension_demo
+   mkdir build
+   cd build
+   cmake ..
+   make
+   ```
+
+   If you need to specify custom paths to dependencies, you can use the following CMake variables:
+   ```bash
+   cmake .. -DAQNWB_DIR=/path/to/aqnwb/build/dev -DHDF5_DIR=/path/to/hdf5 -DBOOST_ROOT=/path/to/boost
+   ```
+
+3. **Run the demo**:
+   ```bash
+   ./bin/labmetadata_extension_demo
+   ```
+
+   This will:
+   - Create a new NWB file named "test.nwb"
+   - Create a LabMetaDataExtensionExample object with tissue preparation details
+   - Write the object to the file
+   - Read the object back from the file
+   - Display the tissue preparation information
+
+### Troubleshooting
+
+If you encounter build errors:
+
+1. **Check dependency paths**: Ensure that the paths to AqNWB, HDF5, and Boost are correctly set in the CMake command or in the CMakeLists.txt file.
+
+2. **Check compiler compatibility**: Make sure your compiler supports C++17 features.
+
+3. **Library linking issues**: If you encounter linking errors, verify that the AqNWB library has been built successfully and that the path to it is correct.

--- a/demo/labmetadata_extension_demo/spec/ndx-labmetadata-example.extensions.yaml
+++ b/demo/labmetadata_extension_demo/spec/ndx-labmetadata-example.extensions.yaml
@@ -1,0 +1,10 @@
+groups:
+- neurodata_type_def: LabMetaDataExtensionExample
+  neurodata_type_inc: LabMetaData
+  name: custom_lab_metadata
+  doc: Example extension type for storing lab metadata
+  datasets:
+  - name: tissue_preparation
+    dtype: text
+    doc: Lab-specific description of the preparation of the tissue
+    quantity: '?'

--- a/demo/labmetadata_extension_demo/spec/ndx-labmetadata-example.namespace.yaml
+++ b/demo/labmetadata_extension_demo/spec/ndx-labmetadata-example.namespace.yaml
@@ -1,0 +1,14 @@
+namespaces:
+- author:
+  - Oliver Ruebel
+  contact:
+  - oruebel@lbl.gov
+  doc: ' Example extension to illustrate how to extend LabMetaData for adding lab-specific
+    metadata'
+  name: ndx-labmetadata-example
+  schema:
+  - namespace: core
+    neurodata_types:
+    - LabMetaData
+  - source: ndx-labmetadata-example.extensions.yaml
+  version: 0.1.0

--- a/demo/labmetadata_extension_demo/src/LabMetaDataExtensionExample.cpp
+++ b/demo/labmetadata_extension_demo/src/LabMetaDataExtensionExample.cpp
@@ -1,0 +1,29 @@
+#include "LabMetaDataExtensionExample.hpp"
+#include "Utils.hpp"
+#include <iostream>
+
+using namespace AQNWB::NWB;
+
+// Initialize the static registered_ member to trigger registration
+REGISTER_SUBCLASS_IMPL(LabMetaDataExtensionExample)
+
+/** Constructor */ 
+LabMetaDataExtensionExample::LabMetaDataExtensionExample(
+    const std::string& path,
+    std::shared_ptr<AQNWB::IO::BaseIO> io)
+    : AQNWB::NWB::Container(path, io)
+{
+    if (path.find(m_nwbBasePath) != 0) {
+        std::cerr << "LabMetaData path expected to appear in "
+                  << m_nwbBasePath <<  " in the NWB file" << std::endl;
+    }
+}
+
+/** Initialize */
+Status LabMetaDataExtensionExample::initialize(const std::string& tissuePreparation)
+{
+  Status containerStatus = Container::initialize();
+  auto tissuePrepPath = AQNWB::mergePaths(m_path, "tissue_preparation");
+  Status tissueDataStatus = m_io->createStringDataSet(tissuePrepPath, tissuePreparation);
+  return containerStatus && tissueDataStatus;
+}

--- a/demo/labmetadata_extension_demo/src/LabMetaDataExtensionExample.hpp
+++ b/demo/labmetadata_extension_demo/src/LabMetaDataExtensionExample.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "nwb/hdmf/base/Container.hpp"
+#include "ndx_labmetadata_example.hpp"
+ 
+class LabMetaDataExtensionExample : public AQNWB::NWB::Container
+{
+public:
+    LabMetaDataExtensionExample(
+        const std::string& path, 
+        std::shared_ptr<AQNWB::IO::BaseIO> io);
+
+    Status initialize(const std::string& tissuePreparation);
+ 
+    DEFINE_FIELD(
+        readTissuePreparation, 
+        AQNWB::NWB::DatasetField, 
+        std::string, 
+        "tissue_preparation", 
+        Lab-specific description of the preparation of the tissue)
+ 
+    // Using the custom macro with the namespace variable
+    REGISTER_SUBCLASS(LabMetaDataExtensionExample, AQNWB::SPEC::NDX_LABMETADATA_EXAMPLE::namespaceName)
+
+private:
+    /// LabMetaData is stored in the NWB file at this location
+    const std::string m_nwbBasePath = "/general";
+};

--- a/demo/labmetadata_extension_demo/src/main.cpp
+++ b/demo/labmetadata_extension_demo/src/main.cpp
@@ -1,0 +1,50 @@
+#include "LabMetaDataExtensionExample.hpp"
+#include "Types.hpp"
+#include "Utils.hpp"
+#include "io/BaseIO.hpp"
+#include "io/hdf5/HDF5IO.hpp"
+#include "nwb/NWBFile.hpp"
+#include <iostream>
+
+// The main routine implementing the main workflow of this demo application
+int main(int argc, char* argv[])
+{
+    // Create the HDF5 I/O object for write
+    std::string filePath = "testLabMetaDataExtensionExample.nwb";
+    
+    // Print progress status
+    std::cout << std::endl << "Opening NWB file: " << filePath << std::endl;
+ 
+    // Create an IO object for writing the NWB file
+    std::shared_ptr<AQNWB::IO::BaseIO> io = std::make_shared<AQNWB::IO::HDF5::HDF5IO>(filePath);
+    io->open();
+
+    // Create the NWBFile
+    std::shared_ptr<AQNWB::NWB::NWBFile> nwbfile = std::make_shared<AQNWB::NWB::NWBFile>(io);
+    nwbfile->initialize("test_identifier", "Test NWB File", "Data collection info");
+
+    // Create the LabMetaDataExtensionExample object
+    std::string labMetaDataPath = AQNWB::mergePaths("/general", "custom_lab_metadata");
+    std::shared_ptr<LabMetaDataExtensionExample> labMetaData = std::make_shared<LabMetaDataExtensionExample>(labMetaDataPath, io);
+    labMetaData->initialize("Tissue preparation details");
+
+    // Close the file
+    io->close();
+
+    // Create a new HDF5 I/O object for read
+    std::shared_ptr<AQNWB::IO::BaseIO> readIO = std::make_shared<AQNWB::IO::HDF5::HDF5IO>(filePath);
+    readIO->open(AQNWB::IO::FileMode::ReadOnly);
+    
+    // Read the LabMetaDataExtensionExample object from the file
+    std::shared_ptr<LabMetaDataExtensionExample> readLabMetaData = std::make_shared<LabMetaDataExtensionExample>(labMetaDataPath, readIO);
+
+    // Read the LabMetaDataExtensionExample.readTissuePreparation field
+    auto tissuePreparationWrapper = readLabMetaData->readTissuePreparation();
+    std::string tissuePreparation = tissuePreparationWrapper->values().data[0];
+    std::cout << "Read Tissue Preparation: " << tissuePreparation << std::endl;
+
+    // Close the read file
+    readIO->close();
+    
+    return 0;
+}

--- a/demo/labmetadata_extension_demo/src/ndx_labmetadata_example.hpp
+++ b/demo/labmetadata_extension_demo/src/ndx_labmetadata_example.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include <string_view>
+#include "spec/NamespaceRegistry.hpp"
+
+namespace AQNWB::SPEC::NDX_LABMETADATA_EXAMPLE
+{
+
+const std::string  namespaceName = "ndx-labmetadata-example";
+
+const std::string version = "0.1.0";
+
+constexpr std::string_view ndx_labmetadata_example_extensions = R"delimiter(
+{"groups":[{"neurodata_type_def":"LabMetaDataExtensionExample","neurodata_type_inc":"LabMetaData","name":"custom_lab_metadata","doc":"Example extension type for storing lab metadata","datasets":[{"name":"tissue_preparation","dtype":"text","doc":"Lab-specific description of the preparation of the tissue","quantity":"?"}]}]})delimiter";
+
+constexpr std::string_view namespaces = R"delimiter(
+{"namespaces":[{"author":["Oliver Ruebel"],"contact":["oruebel@lbl.gov"],"doc":" Example extension to illustrate how to extend LabMetaData for adding lab-specific metadata","name":"ndx-labmetadata-example","schema":[{"namespace":"core","neurodata_types":["LabMetaData"]},{"source":"ndx-labmetadata-example.extensions.yaml"}],"version":"0.1.0"}]})delimiter";
+
+const std::vector<std::pair<std::string_view, std::string_view>>
+    specVariables {{
+  {"ndx-labmetadata-example.extensions", ndx_labmetadata_example_extensions},
+  {"namespace", namespaces}
+
+}};
+
+// Register this namespace with the global registry
+REGISTER_NAMESPACE(namespaceName, version, specVariables)
+
+}  // namespace AQNWB::SPEC::NDX_LABMETADATA_EXAMPLE

--- a/src/nwb/RegisteredType.hpp
+++ b/src/nwb/RegisteredType.hpp
@@ -56,7 +56,7 @@ public:
    * @param path The path of the registered type.
    * @param io A shared pointer to the IO object.
    */
-  RegisteredType(const std::string& path, std::shared_ptr<IO::BaseIO> io);
+  RegisteredType(const std::string& path, std::shared_ptr<AQNWB::IO::BaseIO> io);
 
   /**
    * @brief Destructor.
@@ -85,7 +85,7 @@ public:
    * @brief Get a shared pointer to the IO object.
    * @return Shared pointer to the IO object.
    */
-  inline std::shared_ptr<IO::BaseIO> getIO() const { return m_io; }
+  inline std::shared_ptr<AQNWB::IO::BaseIO> getIO() const { return m_io; }
 
   /**
    * @brief Get the registry of subclass names.
@@ -114,7 +114,7 @@ public:
   static std::unordered_map<
       std::string,
       std::pair<std::function<std::unique_ptr<RegisteredType>(
-                    const std::string&, std::shared_ptr<IO::BaseIO>)>,
+                    const std::string&, std::shared_ptr<AQNWB::IO::BaseIO>)>,
                 std::pair<std::string, std::string>>>&
   getFactoryMap();
 
@@ -131,7 +131,7 @@ public:
   static inline std::shared_ptr<RegisteredType> create(
       const std::string& fullClassName,
       const std::string& path,
-      std::shared_ptr<IO::BaseIO> io)
+      std::shared_ptr<AQNWB::IO::BaseIO> io)
   {
     auto it = getFactoryMap().find(fullClassName);
     if (it != getFactoryMap().end()) {
@@ -151,7 +151,7 @@ public:
    */
   template<typename T>
   static inline std::shared_ptr<T> create(const std::string& path,
-                                          std::shared_ptr<IO::BaseIO> io)
+                                          std::shared_ptr<AQNWB::IO::BaseIO> io)
   {
     static_assert(std::is_base_of<RegisteredType, T>::value,
                   "T must be a derived class of RegisteredType");
@@ -171,7 +171,7 @@ public:
    * if creation fails.
    */
   static std::shared_ptr<AQNWB::NWB::RegisteredType> create(
-      const std::string& path, std::shared_ptr<IO::BaseIO> io);
+      const std::string& path, std::shared_ptr<AQNWB::IO::BaseIO> io);
 
   /**
    * @brief Get the name of the class type.
@@ -235,10 +235,10 @@ public:
            typename VTYPE,
            typename std::enable_if<Types::IsDataStorageObjectType<SOT>::value,
                                    int>::type = 0>
-  inline std::unique_ptr<IO::ReadDataWrapper<SOT, VTYPE>> readField(
+  inline std::unique_ptr<AQNWB::IO::ReadDataWrapper<SOT, VTYPE>> readField(
       const std::string& fieldPath) const
   {
-    return std::make_unique<IO::ReadDataWrapper<SOT, VTYPE>>(
+    return std::make_unique<AQNWB::IO::ReadDataWrapper<SOT, VTYPE>>(
         m_io, AQNWB::mergePaths(m_path, fieldPath));
   }
 
@@ -276,7 +276,7 @@ public:
    */
   virtual std::unordered_map<std::string, std::string> findOwnedTypes(
       const std::unordered_set<std::string>& types = {},
-      const IO::SearchMode& search_mode = IO::SearchMode::STOP_ON_TYPE) const;
+      const AQNWB::IO::SearchMode& search_mode = AQNWB::IO::SearchMode::STOP_ON_TYPE) const;
 
 protected:
   /**
@@ -291,7 +291,7 @@ protected:
   static void registerSubclass(
       const std::string& fullClassName,
       std::function<std::unique_ptr<RegisteredType>(
-          const std::string&, std::shared_ptr<IO::BaseIO>)> factoryFunction,
+          const std::string&, std::shared_ptr<AQNWB::IO::BaseIO>)> factoryFunction,
       const std::string& typeName,
       const std::string& typeNamespace);
 
@@ -303,7 +303,7 @@ protected:
   /**
    * @brief A shared pointer to the IO object.
    */
-  std::shared_ptr<IO::BaseIO> m_io;
+  std::shared_ptr<AQNWB::IO::BaseIO> m_io;
 };
 
 /**
@@ -326,7 +326,7 @@ protected:
   { \
     AQNWB::NWB::RegisteredType::registerSubclass( \
         NAMESPACE "::" #T, \
-        [](const std::string& path, std::shared_ptr<IO::BaseIO> io) \
+        [](const std::string& path, std::shared_ptr<AQNWB::IO::BaseIO> io) \
             -> std::unique_ptr<AQNWB::NWB::RegisteredType> \
         { return std::make_unique<T>(path, io); }, \
         TYPENAME, \
@@ -398,10 +398,10 @@ protected:
    * description \
    */ \
   template<typename VTYPE = default_type> \
-  inline std::unique_ptr<IO::ReadDataWrapper<storageObjectType, VTYPE>> name() \
+  inline std::unique_ptr<AQNWB::IO::ReadDataWrapper<storageObjectType, VTYPE>> name() \
       const \
   { \
-    return std::make_unique<IO::ReadDataWrapper<storageObjectType, VTYPE>>( \
+    return std::make_unique<AQNWB::IO::ReadDataWrapper<storageObjectType, VTYPE>>( \
         m_io, AQNWB::mergePaths(m_path, fieldPath)); \
   }
 


### PR DESCRIPTION
Fix #182 

This PR adds a small demo program to illustrate how to implement and use an extension with AqNWB. Specifically this PR:

- [X] Added `demo/labmetadata_extension_demo` with the demo. Including:
     - [X] README.md discussing the demo
     - [X] CMakeLists.txt for building the demo 
     - [X] `spec/` folder with the YAML sources of the example extension
     - [X] `src/` folder with the:
           - [X] schema header file generated via `generate_spec_file.py` 
           - [X] implementation of the `LabMetaDataExtensionExample` RegisteredType class
           - [X] `main.py`with a simple example app for writing and reading data with the extension
     - [X] Updated `RegisteredType` class to always fully qualify the `AQNWB::IO` namespace. This is needed because the macros are used in other header files and if they don't specify that they use the `AQNWB::IO` namespace then this leads to compiler errors
     - [X] #181 updates `RegisteredType` and the  `generate_spec_file.py` to work with the enhanced extension setup
- [ ] Include the example in the documentation