### PR TITLE
DRAFT: Explore multiton for registered types

### DIFF
--- a/src/nwb/RegisteredType.cpp
+++ b/src/nwb/RegisteredType.cpp
@@ -72,12 +72,25 @@ std::string RegisteredType::getNamespace() const
   return "";
 }
 
+std::shared_ptr<RegisteredType> RegisteredType::getExistingInstance(const std::string& path, std::shared_ptr<AQNWB::IO::BaseIO> io)
+{
+  auto recordingObjects = io->getRecordingObjects();
+  auto existingObject = recordingObjects->getRecordingObject(path);
+  return existingObject;
+}
+
 std::shared_ptr<AQNWB::NWB::RegisteredType> RegisteredType::create(
     const std::string& fullClassName,
     const std::string& path,
     std::shared_ptr<IO::BaseIO> io,
     bool fallbackToBase)
 {
+  // Check the RecordingObjects cache if an object already exists
+  auto existingObject = RegisteredType::getExistingInstance(path, io);
+  if (existingObject != nullptr){
+    return existingObject;
+  }
+  
   // If no object exists for the path, or if the existing object is of a
   // different type, create a new instance
   //  Look up the factory RegisteredType for the fullClassName the registry

--- a/src/nwb/RegisteredType.cpp
+++ b/src/nwb/RegisteredType.cpp
@@ -72,7 +72,8 @@ std::string RegisteredType::getNamespace() const
   return "";
 }
 
-std::shared_ptr<RegisteredType> RegisteredType::getExistingInstance(const std::string& path, std::shared_ptr<AQNWB::IO::BaseIO> io)
+std::shared_ptr<RegisteredType> RegisteredType::getExistingInstance(
+    const std::string& path, std::shared_ptr<AQNWB::IO::BaseIO> io)
 {
   auto recordingObjects = io->getRecordingObjects();
   auto existingObject = recordingObjects->getRecordingObject(path);
@@ -87,10 +88,10 @@ std::shared_ptr<AQNWB::NWB::RegisteredType> RegisteredType::create(
 {
   // Check the RecordingObjects cache if an object already exists
   auto existingObject = RegisteredType::getExistingInstance(path, io);
-  if (existingObject != nullptr){
+  if (existingObject != nullptr) {
     return existingObject;
   }
-  
+
   // If no object exists for the path, or if the existing object is of a
   // different type, create a new instance
   //  Look up the factory RegisteredType for the fullClassName the registry

--- a/src/nwb/RegisteredType.hpp
+++ b/src/nwb/RegisteredType.hpp
@@ -245,10 +245,12 @@ public:
                   "T must be a derived class of RegisteredType");
     // Check if we have existing instance
     auto existingObject = RegisteredType::getExistingInstance(path, io);
-    if (existingObject != nullptr){
-      auto castExistingPointer =  std::dynamic_pointer_cast<T>(existingObject);
-      if(castExistingPointer == nullptr){
-        std::cerr<<"Failed to cast existing object of type "<<existingObject->getFullTypeName()<<" to requested type"<<std::endl;
+    if (existingObject != nullptr) {
+      auto castExistingPointer = std::dynamic_pointer_cast<T>(existingObject);
+      if (castExistingPointer == nullptr) {
+        std::cerr << "Failed to cast existing object of type "
+                  << existingObject->getFullTypeName() << " to requested type"
+                  << std::endl;
       }
       return castExistingPointer;
     }
@@ -377,12 +379,13 @@ public:
       const AQNWB::IO::SearchMode& search_mode =
           AQNWB::IO::SearchMode::STOP_ON_TYPE) const;
 
-  /** \brief Check if an instance already exists for the given path and io 
+  /** \brief Check if an instance already exists for the given path and io
    * @param path The path of the container.
    * @param io A shared pointer to the IO object.
-   * @return A shared_ptr to the created instance of the subclass. 
+   * @return A shared_ptr to the created instance of the subclass.
    */
-  static std::shared_ptr<RegisteredType> getExistingInstance(const std::string& path, std::shared_ptr<AQNWB::IO::BaseIO> io);
+  static std::shared_ptr<RegisteredType> getExistingInstance(
+      const std::string& path, std::shared_ptr<AQNWB::IO::BaseIO> io);
 
 protected:
   /**

--- a/src/nwb/RegisteredType.hpp
+++ b/src/nwb/RegisteredType.hpp
@@ -243,6 +243,17 @@ public:
   {
     static_assert(std::is_base_of<RegisteredType, T>::value,
                   "T must be a derived class of RegisteredType");
+    // Check if we have existing instance
+    auto existingObject = RegisteredType::getExistingInstance(path, io);
+    if (existingObject != nullptr){
+      auto castExistingPointer =  std::dynamic_pointer_cast<T>(existingObject);
+      if(castExistingPointer == nullptr){
+        std::cerr<<"Failed to cast existing object of type "<<existingObject->getFullTypeName()<<" to requested type"<<std::endl;
+      }
+      return castExistingPointer;
+    }
+
+    // Create a new instance and register it
     auto result = std::shared_ptr<T>(new T(path, io));
     result->registerRecordingObject();
     return result;
@@ -365,6 +376,13 @@ public:
       const std::unordered_set<std::string>& types = {},
       const AQNWB::IO::SearchMode& search_mode =
           AQNWB::IO::SearchMode::STOP_ON_TYPE) const;
+
+  /** \brief Check if an instance already exists for the given path and io 
+   * @param path The path of the container.
+   * @param io A shared pointer to the IO object.
+   * @return A shared_ptr to the created instance of the subclass. 
+   */
+  static std::shared_ptr<RegisteredType> getExistingInstance(const std::string& path, std::shared_ptr<AQNWB::IO::BaseIO> io);
 
 protected:
   /**


### PR DESCRIPTION
This PR is to evaluate whether `RegisteredType::create` should look up if an object with the same path and I/O already exists by looking up the object via `io->getRecordingObjects()->getRecordingObject(path)` and return the existing object. 

➕  This would avoid creating duplicate objects to prevent creation of different objects that modify the same file object.
➖ This sort of `multiton` pattern may be too restrictive for users. 
➖  In addition to `create` this will also require some rethinking of the templated RegisteredType class, e.g., `VectorDataTyped`. For these we may have an untyped `VectorData` first for which we then create `VectorDataTyped` for read only. This would not be allowed by  `RegisteredType::create`. However, is this needed? If yes, should `VectorDataTyped` be declared a read-only type to avoid issues?

I think there is a balance to be found here between preventing the user of the API from potentially doing bad things by creating multiple objects for the same path/io and limiting flexibility of the API. I am currently leaning towards documenting the best practice and not restricting the API in this way. @stephprince thoughts?