### PR TITLE
Update status checks in recording workflow

### DIFF
--- a/src/Utils.hpp
+++ b/src/Utils.hpp
@@ -202,4 +202,9 @@ static inline std::unique_ptr<int16_t[]> transformToInt16(
   return intData;
 }
 
+auto checkStatus = [](Status status, const std::string& operation) {
+    if (status != Status::Success) {
+        std::cerr << operation << " failed" << std::endl;
+    }
+};
 }  // namespace AQNWB

--- a/src/io/hdf5/HDF5IO.cpp
+++ b/src/io/hdf5/HDF5IO.cpp
@@ -86,7 +86,7 @@ Status HDF5IO::close()
   return Status::Success;
 }
 
-Status checkStatus(int status)
+Status intToStatus(int status)
 {
   if (status < 0)
     return Status::Failure;
@@ -97,7 +97,7 @@ Status checkStatus(int status)
 Status HDF5IO::flush()
 {
   int status = H5Fflush(m_file->getId(), H5F_SCOPE_GLOBAL);
-  return checkStatus(status);
+  return intToStatus(status);
 }
 
 std::unique_ptr<H5::Attribute> HDF5IO::getAttribute(
@@ -977,7 +977,7 @@ Status HDF5IO::createLink(const std::string& path, const std::string& reference)
                                 H5P_DEFAULT,
                                 H5P_DEFAULT);
 
-  return checkStatus(error);
+  return intToStatus(error);
 }
 
 Status HDF5IO::createReferenceDataSet(
@@ -1011,16 +1011,16 @@ Status HDF5IO::createReferenceDataSet(
   delete[] rdata;
 
   herr_t dsetStatus = H5Dclose(dset);
-  if (checkStatus(dsetStatus) == Status::Failure) {
+  if (intToStatus(dsetStatus) == Status::Failure) {
     return Status::Failure;
   }
 
   herr_t spaceStatus = H5Sclose(space);
-  if (checkStatus(spaceStatus) == Status::Failure) {
+  if (intToStatus(spaceStatus) == Status::Failure) {
     return Status::Failure;
   }
 
-  return checkStatus(writeStatus);
+  return intToStatus(writeStatus);
 }
 
 Status HDF5IO::createStringDataSet(const std::string& path,
@@ -1069,7 +1069,7 @@ Status HDF5IO::startRecording()
 
   if (!m_disableSWMRMode) {
     herr_t status = H5Fstart_swmr_write(m_file->getId());
-    return checkStatus(status);
+    return intToStatus(status);
   }
   return Status::Success;
 }

--- a/src/io/hdf5/HDF5RecordingData.hpp
+++ b/src/io/hdf5/HDF5RecordingData.hpp
@@ -90,9 +90,9 @@ private:
                               H5::DataSpace& fSpace);
 
   /**
-   * @brief Return status of HDF5 operations.
+   * @brief Convert int status of HDF5 operations to AQNWB status.
    */
-  Status checkStatus(int status);
+  Status intToStatus(int status);
 
   /**
    * @brief Pointer to an extendable HDF5 dataset

--- a/tests/examples/testWorkflowExamples.cpp
+++ b/tests/examples/testWorkflowExamples.cpp
@@ -38,8 +38,8 @@ TEST_CASE("workflowExamples")
     // [example_workflow_io_snippet]
     std::shared_ptr<BaseIO> io = createIO("HDF5", path);
     io->open();
-    REQUIRE(io->isOpen());
     // [example_workflow_io_snippet]
+    REQUIRE(io->isOpen());
 
     // [example_workflow_recording_containers_snippet]
     std::unique_ptr<NWB::RecordingContainers> recordingContainers =
@@ -49,14 +49,16 @@ TEST_CASE("workflowExamples")
     // [example_workflow_nwbfile_snippet]
     std::unique_ptr<NWB::NWBFile> nwbfile = std::make_unique<NWB::NWBFile>(io);
     Status initStatus = nwbfile->initialize(generateUuid());
-    REQUIRE(initStatus == Status::Success);
+    AQNWB::checkStatus(initStatus, "NWBFile initialization");
     // [example_workflow_nwbfile_snippet]
+    REQUIRE(initStatus == Status::Success);
 
     // [example_workflow_electrodes_table_snippet]
     Status elecTableStatus =
         nwbfile->createElectrodesTable(mockRecordingArrays);
-    REQUIRE(elecTableStatus == Status::Success);
+    AQNWB::checkStatus(elecTableStatus, "ElectrodesTable creation");
     // [example_workflow_electrodes_table_snippet]
+    REQUIRE(elecTableStatus == Status::Success);
 
     // [example_workflow_datasets_snippet]
     std::vector<SizeType> containerIndexes;
@@ -66,13 +68,15 @@ TEST_CASE("workflowExamples")
                                         BaseDataType::I16,
                                         recordingContainers.get(),
                                         containerIndexes);
-    REQUIRE(elecSeriesStatus == Status::Success);
+    AQNWB::checkStatus(elecSeriesStatus, "ElectricalSeries creation");
     // [example_workflow_datasets_snippet]
+    REQUIRE(elecSeriesStatus == Status::Success);
 
     // [example_workflow_start_snippet]
     Status startRecordingStatus = io->startRecording();
-    REQUIRE(startRecordingStatus == Status::Success);
+    AQNWB::checkStatus(startRecordingStatus, "Start recording");
     // [example_workflow_start_snippet]
+    REQUIRE(startRecordingStatus == Status::Success);
 
     // write data during the recording
     bool isRecording = true;
@@ -138,9 +142,11 @@ TEST_CASE("workflowExamples")
                                         {samplesRecorded},
                                         BaseDataType::F64,
                                         timestampsBuffer.data());
+    AQNWB::checkStatus(writeDataStatus, "Write data");
+    AQNWB::checkStatus(writeTimestampsStatus, "Write timestamps");
+    // [example_workflow_advanced_snippet]
     REQUIRE(writeDataStatus == Status::Success);
     REQUIRE(writeTimestampsStatus == Status::Success);
-    // [example_workflow_advanced_snippet]
 
     // [example_workflow_stop_snippet]
     io->stopRecording();


### PR DESCRIPTION
When updating the recording workflow for the Open Ephys integration, I realized that our current demo uses `REQUIRE` from the Catch2 testing suite. I believe when developing an integration we do not want to require users to have the Catch2 testing framework installed.

Instead I added a simple status check util to print to the standard error stream (we could update with more sophisticated logging at some point as mentioned in https://github.com/NeurodataWithoutBorders/aqnwb/issues/121). I've updated the examples to still use the REQUIRE statements so that we can check when our workflow examples, but our examples will now demonstrate checking the status with a simple status check function. 