### PR TITLE
Move disableSWMRMode from constructor to startRecording in HDF5IO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `ElectricalSeries::channelsAtSameSampleOffset` method to check if all channels are at the same sample offset, which is a requirement for using `writeAllChannels`. (@copilot, @oruebel, [#293](https://github.com/NeurodataWithoutBorders/aqnwb/pull/293))
 
 ### Changed
-* ...
+* **[BREAKING]** Moved `disableSWMRMode` option from `HDF5IO` constructor to a new `HDF5IO::startRecording(bool disableSWMRMode)` overload. The `BaseIO`-compliant `startRecording()` override is preserved and defaults to SWMR enabled. 
+   * **Migration Note**: Code using `HDF5IO(path, true)` must be updated to `HDF5IO(path)` followed by `startRecording(true)`. When the `HDF5IO` object is held as a `std::shared_ptr<BaseIO>` (e.g., from `createIO`), downcast with `std::dynamic_pointer_cast<HDF5IO>` to access the overload. (@oruebel [#297](https://github.com/NeurodataWithoutBorders/aqnwb/pull/297))
 
 ### Fixed
 * Updated nwbinspector validation tests in the CI to: 1) `--ignore=check_subject_exists` and 2) remove dependency on `sanitizer` tests to speed up CI (@oruebel, [#289](https://github.com/NeurodataWithoutBorders/aqnwb/pull/289))

--- a/docs/pages/userdocs/hdf5io.dox
+++ b/docs/pages/userdocs/hdf5io.dox
@@ -231,6 +231,19 @@
  * you can disable the use of SWMR mode by passing `disableSWMRMode=true` to
  * \ref AQNWB::IO::HDF5::HDF5IO::startRecording(bool) "HDF5IO::startRecording(bool)".
  *
+ * \note
+ * `startRecording(bool)` is an `HDF5IO`-specific overload and is not part of the
+ * \ref AQNWB::IO::BaseIO "BaseIO" interface. If the I/O object was created via
+ * \ref AQNWB::createIO "createIO" (which returns `std::shared_ptr<BaseIO>`),
+ * downcast to `HDF5IO` using `std::dynamic_pointer_cast` before calling it:
+ * \code{.cpp}
+ * std::shared_ptr<IO::BaseIO> io = createIO("HDF5", path);
+ * io->open();
+ * // ... create datasets and groups ...
+ * auto hdf5io = std::dynamic_pointer_cast<IO::HDF5::HDF5IO>(io);
+ * hdf5io->startRecording(true);  // disable SWMR mode
+ * \endcode
+ *
  * \warning
  * While disabling SWMR mode allows Groups and Datasets to be created during and after
  * recording, this comes at the  cost of losing the concurrent access and data integrity

--- a/docs/pages/userdocs/hdf5io.dox
+++ b/docs/pages/userdocs/hdf5io.dox
@@ -228,8 +228,8 @@
  *
  * This workflow is applicable to a wide range of data acquisition use-cases. However,
  * for use cases that require creation of new Groups and Datasets during acquisition,
- * you can disable the use of SWMR mode by setting `disableSWMRMode=true` when
- * constructing the \ref AQNWB::IO::HDF5::HDF5IO object.
+ * you can disable the use of SWMR mode by passing `disableSWMRMode=true` to
+ * \ref AQNWB::IO::HDF5::HDF5IO::startRecording(bool) "HDF5IO::startRecording(bool)".
  *
  * \warning
  * While disabling SWMR mode allows Groups and Datasets to be created during and after

--- a/src/io/hdf5/HDF5IO.cpp
+++ b/src/io/hdf5/HDF5IO.cpp
@@ -21,9 +21,9 @@ using namespace H5;
 using namespace AQNWB::IO::HDF5;
 
 // HDF5IO
-HDF5IO::HDF5IO(const std::string& fileName, const bool disableSWMRMode)
+HDF5IO::HDF5IO(const std::string& fileName)
     : BaseIO(fileName)
-    , m_disableSWMRMode(disableSWMRMode)
+    , m_disableSWMRMode(false)
 {
 }
 
@@ -1071,9 +1071,15 @@ Status HDF5IO::createStringDataSet(const std::string& path,
 
 Status HDF5IO::startRecording()
 {
+  return startRecording(false);
+}
+
+Status HDF5IO::startRecording(bool disableSWMRMode)
+{
   if (!m_opened) {
     return Status::Failure;
   }
+  m_disableSWMRMode = disableSWMRMode;
   // Call the base class method to pre-finalize all recording objects
   Status status = BaseIO::startRecording();
   // Start SWMR mode if it is not disabled

--- a/src/io/hdf5/HDF5IO.cpp
+++ b/src/io/hdf5/HDF5IO.cpp
@@ -1071,7 +1071,7 @@ Status HDF5IO::createStringDataSet(const std::string& path,
 
 Status HDF5IO::startRecording()
 {
-  return startRecording(false);
+  return startRecording(m_disableSWMRMode);
 }
 
 Status HDF5IO::startRecording(bool disableSWMRMode)

--- a/src/io/hdf5/HDF5IO.hpp
+++ b/src/io/hdf5/HDF5IO.hpp
@@ -41,14 +41,8 @@ public:
   /**
    * @brief Constructor for the HDF5IO class that takes a file name as input.
    * @param fileName The name of the HDF5 file.
-   * @param disableSWMRMode Disable recording of data in Single Writer
-   *                 Multiple Reader (SWMR) mode. Using SWMR ensures that the
-   *                 HDF5 file remains valid and readable at all times during
-   *                 the recording process (but does not allow for new objects
-   *                 (Groups or Datasets) to be created.
    */
-  explicit HDF5IO(const std::string& fileName,
-                  const bool disableSWMRMode = false);
+  explicit HDF5IO(const std::string& fileName);
 
   /**
    * @brief Destructor.
@@ -237,10 +231,25 @@ public:
       const std::vector<std::string>& references) override;
 
   /**
-   * @brief Start SWMR write to start recording process
+   * @brief Start SWMR write to start recording process.
    * @return The status of the start recording operation.
    */
   Status startRecording() override;
+
+  /**
+   * @brief Start recording, optionally disabling SWMR mode.
+   *
+   * This overload is specific to @ref HDF5IO and is not part of the
+   * @ref BaseIO interface. Disabling SWMR mode allows new objects (Groups,
+   * Datasets, etc.) to be created during recording, but loses the data
+   * consistency and concurrent read guarantees that SWMR mode provides.
+   * When SWMR is disabled, @ref stopRecording will flush data to disk
+   * instead of closing the file, allowing recording to be restarted.
+   *
+   * @param disableSWMRMode When true, do not switch to SWMR mode.
+   * @return The status of the start recording operation.
+   */
+  Status startRecording(bool disableSWMRMode);
 
   /**
    * @brief Stops the recording process.
@@ -494,8 +503,8 @@ private:
   std::unique_ptr<H5::H5File> m_file;
 
   /**
-   * \brief When set true, then do not switch to SWMR mode when starting the
-   * recording
+   * \brief Tracks whether SWMR mode is disabled for the current recording.
+   * Set by @ref startRecording(bool) at the start of each recording cycle.
    */
   bool m_disableSWMRMode;
 };

--- a/tests/examples/test_HDF5IO_examples.cpp
+++ b/tests/examples/test_HDF5IO_examples.cpp
@@ -74,12 +74,10 @@ TEST_CASE("SWMRmodeExamples", "[hdf5io]")
   SECTION("disableSWMRMode")
   {
     // [example_HDF5_without_SWMR_mode]
-    // create and open the HDF5 file. With SWMR mode explicitly disabled
+    // create and open the HDF5 file
     std::string path = getTestFilePath("testWithoutSWMRMode.h5");
     std::unique_ptr<AQNWB::IO::HDF5::HDF5IO> hdf5io =
-        std::make_unique<AQNWB::IO::HDF5::HDF5IO>(path,
-                                                  true  // Disable SWMR mode
-        );
+        std::make_unique<AQNWB::IO::HDF5::HDF5IO>(path);
     hdf5io->open();
 
     // add a dataset
@@ -97,8 +95,10 @@ TEST_CASE("SWMRmodeExamples", "[hdf5io]")
         datasetConfig,
         dataPath);  // path. Path to the dataset in the HDF5 file
 
-    // Start recording. Starting the recording places the HDF5 file in SWMR mode
-    Status status = hdf5io->startRecording();
+    // Start recording with SWMR mode disabled. This allows new objects to be
+    // created during recording, but loses data consistency and concurrent read
+    // guarantees that SWMR mode provides.
+    Status status = hdf5io->startRecording(true);
     REQUIRE(status == Status::Success);
 
     // With SWMR mode disabled we are still allowed to create new data objects
@@ -124,8 +124,8 @@ TEST_CASE("SWMRmodeExamples", "[hdf5io]")
     // so that we can restart the recording if we want to
     REQUIRE(hdf5io->isOpen() == true);
 
-    // Restart the recording
-    REQUIRE(hdf5io->startRecording() == Status::Success);
+    // Restart the recording with SWMR mode disabled
+    REQUIRE(hdf5io->startRecording(true) == Status::Success);
 
     // Stop the recording and close the file
     hdf5io->stopRecording();

--- a/tests/testHDF5IO.cpp
+++ b/tests/testHDF5IO.cpp
@@ -1022,7 +1022,7 @@ TEST_CASE("HDF5IO; SWMR mode", "[hdf5io]")
     // create and open file with SWMR mode disabled
     std::string path = getTestFilePath("testSWMRmodeDisable.h5");
     std::unique_ptr<IO::HDF5::HDF5IO> hdf5io =
-        std::make_unique<IO::HDF5::HDF5IO>(path, true);
+        std::make_unique<IO::HDF5::HDF5IO>(path);
     hdf5io->open();
 
     // add a dataset
@@ -1035,8 +1035,9 @@ TEST_CASE("HDF5IO; SWMR mode", "[hdf5io]")
     std::unique_ptr<BaseRecordingData> dataset =
         hdf5io->createArrayDataSet(datasetConfig, dataPath);
 
-    // start recording, check that can still modify objects
-    Status status = hdf5io->startRecording();
+    // start recording with SWMR mode disabled, check that can still modify
+    // objects
+    Status status = hdf5io->startRecording(true);
     REQUIRE(status == Status::Success);
     REQUIRE(hdf5io->canModifyObjects() == true);
 
@@ -1062,7 +1063,7 @@ TEST_CASE("HDF5IO; SWMR mode", "[hdf5io]")
     REQUIRE(hdf5io->isOpen() == true);
 
     // restart recording and write to a dataset
-    Status statusRestart = hdf5io->startRecording();
+    Status statusRestart = hdf5io->startRecording(true);
     REQUIRE(statusRestart == Status::Success);
 
     std::string dataPathPostRestart = "/dataPostRestart/data";


### PR DESCRIPTION
Fix #296 

Moved the `disableSWMRMode` option from the `HDF5IO` constructor to a new `HDF5IO::startRecording(bool disableSWMRMode)` overload. This approach ensures that:
- the `disableSWMRMode` option is being set where it is being first used
- the option is accessible even when `createIO` is used to construct the `HDF5IO` object. However, this requires casting of the returned `BaseIO` object to access `HDF5IO`-specific options. 

Changes:

 - **src/io/hdf5/HDF5IO.hpp/cpp**: Removed `disableSWMRMode` from constructor, added `startRecording(bool disableSWMRMode)` overload declaration, and updated the documentation for `m_disableSWMRMode` accordingly.
 - **tests/testHDF5IO.cpp,  tests/examples/test_HDF5IO_examples.cpp**: Updated HDF5IO unit tests that used the disableSWMRMode option.
 - **docs/pages/userdocs/hdf5io.dox**: Updated description of how to disable SWMR mode to reference startRecording(bool) instead of the constructor.
